### PR TITLE
Fix contacts management and improve beautify/chat UX

### DIFF
--- a/src/app/api/email-beautify/route.ts
+++ b/src/app/api/email-beautify/route.ts
@@ -415,57 +415,68 @@ RESPOND WITH ONLY THIS JSON FORMAT (no other text):
     const completion = await openai.chat.completions.create({
       model: "gpt-4o-mini",
       messages: [
-        { 
-          role: "system", 
-          content: "You are an expert email designer and copywriter. You help create beautiful, professional HTML email layouts. IMPORTANT: Always respond with ONLY valid JSON in the exact format specified. Do not include any explanations, markdown formatting, or additional text outside the JSON object." 
+        {
+          role: "system",
+          content: "You are an expert email designer and copywriter. You help create beautiful, professional HTML email layouts. IMPORTANT: Always respond with ONLY valid JSON in the exact format specified. Do not include any explanations, markdown formatting, or additional text outside the JSON object."
         },
         { role: "user", content: enhancementPrompt }
       ],
       temperature: 0.7,
       max_tokens: 3000, // Increased from 1500 to handle larger emails
+      response_format: { type: "json_object" }, // Enforce JSON mode for reliable parsing
     });
-    
+
     const aiResponse = completion.choices[0]?.message?.content || '{}';
-    
+
     let aiEnhancements;
     try {
       // Clean up the response to ensure it's valid JSON
       let cleanedResponse = aiResponse.trim();
-      
+
       // Remove markdown code blocks if present
       if (cleanedResponse.startsWith('```json')) {
         cleanedResponse = cleanedResponse.replace(/^```json\s*/, '').replace(/\s*```$/, '');
       } else if (cleanedResponse.startsWith('```')) {
         cleanedResponse = cleanedResponse.replace(/^```\s*/, '').replace(/\s*```$/, '');
       }
-      
+
       // Try to find JSON object in the response if it contains other text
       const jsonMatch = cleanedResponse.match(/\{[\s\S]*\}/);
       if (jsonMatch) {
         cleanedResponse = jsonMatch[0];
       }
-      
-      // Validate the response contains required fields before parsing
-      if (!cleanedResponse.includes('"formattedContent"')) {
-        throw new Error('Response missing required formattedContent field');
-      }
-      
+
       aiEnhancements = JSON.parse(cleanedResponse);
-      
+
       // Validate the parsed object has required fields
-      if (!aiEnhancements.formattedContent) {
+      if (!aiEnhancements || !aiEnhancements.formattedContent) {
         throw new Error('Parsed response missing formattedContent');
       }
-      
+
     } catch (parseError) {
       console.error('JSON parsing error:', parseError);
       console.error('Raw AI response:', aiResponse);
-      
-      // Fallback if AI response isn't valid JSON
+
+      // Fallback: build sensible HTML content from the original message
+      // Split into paragraphs by blank lines so we don't collapse intentional spacing,
+      // and promote the first non-empty line to a subheading for visual hierarchy.
+      const paragraphs = message
+        .split(/\n\s*\n/)
+        .map((p: string) => p.trim())
+        .filter((p: string) => p.length > 0);
+
+      const formattedParagraphs = paragraphs.map((para: string, idx: number) => {
+        const withBreaks = para.replace(/\n/g, '<br>');
+        if (idx === 0 && paragraphs.length > 1 && para.length < 80) {
+          return `<h2>${withBreaks}</h2>`;
+        }
+        return `<p>${withBreaks}</p>`;
+      }).join('\n');
+
       aiEnhancements = {
         enhancedSubject: subject,
         subtitle: '',
-        formattedContent: `<p>${message.replace(/\n/g, '</p><p>')}</p>`,
+        formattedContent: formattedParagraphs || `<p>${message}</p>`,
         signature: orgName || 'Your Organization'
       };
     }

--- a/src/app/mass-text/page.tsx
+++ b/src/app/mass-text/page.tsx
@@ -132,6 +132,40 @@ export default function MassTextPage() {
   const [isBeautifiedEmail, setIsBeautifiedEmail] = useState(false)
   const [selectedMember, setSelectedMember] = useState<Contact | null>(null)
   const [showProfileDialog, setShowProfileDialog] = useState(false)
+  const [contactSearch, setContactSearch] = useState("")
+  const [contactStatusFilter, setContactStatusFilter] = useState<'all' | 'active' | 'opted-out'>('all')
+  const [contactSortBy, setContactSortBy] = useState<'name' | 'recent'>('name')
+  const [showEditContactDialog, setShowEditContactDialog] = useState(false)
+  const [contactToDelete, setContactToDelete] = useState<Contact | null>(null)
+  const [contactsFeedback, setContactsFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+
+  // Auto-dismiss contacts feedback after a short delay
+  useEffect(() => {
+    if (!contactsFeedback) return
+    const timer = setTimeout(() => setContactsFeedback(null), 3500)
+    return () => clearTimeout(timer)
+  }, [contactsFeedback])
+
+  // Derived filtered + sorted contacts for the management view
+  const filteredContacts = (() => {
+    const query = contactSearch.trim().toLowerCase()
+    const filtered = originalContacts.filter((c) => {
+      if (contactStatusFilter === 'active' && c.opted_out) return false
+      if (contactStatusFilter === 'opted-out' && !c.opted_out) return false
+      if (!query) return true
+      return (
+        (c.name || '').toLowerCase().includes(query) ||
+        (c.email || '').toLowerCase().includes(query) ||
+        (c.phone || '').toLowerCase().includes(query)
+      )
+    })
+    if (contactSortBy === 'name') {
+      filtered.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+    } else {
+      filtered.sort((a, b) => (b.id || 0) - (a.id || 0))
+    }
+    return filtered
+  })()
 
   // Add authentication check and fetch org info
   useEffect(() => {
@@ -556,14 +590,18 @@ export default function MassTextPage() {
     }
   };
 
-  const handleDeleteContact = (index: number) => {
-    // If in contacts management mode, delete from database
-    if (viewMode === 'contacts-management' && originalContacts[index]?.id) {
-      setDeletingContactId(originalContacts[index].id!);
+  const handleDeleteContact = (indexOrContact: number | Contact) => {
+    // Resolve the target contact from either an index (legacy) or a contact object
+    const target =
+      typeof indexOrContact === 'number' ? originalContacts[indexOrContact] : indexOrContact;
+
+    if (viewMode === 'contacts-management' && target?.id) {
+      setContactToDelete(target);
+      setDeletingContactId(target.id);
       setIsDeleting(true);
-    } else {
+    } else if (typeof indexOrContact === 'number') {
       const updatedContacts = [...contacts];
-      updatedContacts.splice(index, 1);
+      updatedContacts.splice(indexOrContact, 1);
       setContacts(updatedContacts);
     }
   }
@@ -584,10 +622,12 @@ export default function MassTextPage() {
         throw new Error(data.message || 'Failed to delete contact');
       }
 
-      // Refresh the contacts list
       await fetchContactsFromSupabase();
+      const deletedName = contactToDelete?.name || 'Member';
       setIsDeleting(false);
       setDeletingContactId(null);
+      setContactToDelete(null);
+      setContactsFeedback({ type: 'success', message: `${deletedName} deleted successfully` });
 
     } catch (error) {
       console.error('Error deleting contact:', error);
@@ -595,22 +635,35 @@ export default function MassTextPage() {
       setError(errorMessage);
       setIsDeleting(false);
       setDeletingContactId(null);
+      setContactToDelete(null);
+      setContactsFeedback({ type: 'error', message: errorMessage });
     }
   };
 
-  // Function to handle editing a contact
+  // Function to handle editing a contact — opens the edit dialog
   const handleEditContact = (contact: Contact) => {
-    setEditingContact(contact);
+    setEditingContact({ ...contact });
+    setShowEditContactDialog(true);
   };
 
   // Function to save edited contact
   const handleSaveContact = async () => {
     if (!editingContact || !editingContact.id) return;
 
+    const trimmedName = (editingContact.name || '').trim();
+    if (!trimmedName) {
+      setContactsFeedback({ type: 'error', message: 'Name cannot be empty' });
+      return;
+    }
+    if (!editingContact.phone || !editingContact.phone.trim()) {
+      setContactsFeedback({ type: 'error', message: 'Phone number cannot be empty' });
+      return;
+    }
+
     try {
       setError(null);
 
-      const nameParts = editingContact.name.split(' ');
+      const nameParts = trimmedName.split(/\s+/);
       const first_name = nameParts[0] || '';
       const last_name = nameParts.slice(1).join(' ') || '';
 
@@ -623,7 +676,7 @@ export default function MassTextPage() {
           id: editingContact.id,
           first_name,
           last_name,
-          email: editingContact.email,
+          email: editingContact.email ?? '',
           phone_number: editingContact.phone
         }),
       });
@@ -633,14 +686,16 @@ export default function MassTextPage() {
         throw new Error(data.message || 'Failed to update contact');
       }
 
-      // Refresh the contacts list
       await fetchContactsFromSupabase();
       setEditingContact(null);
+      setShowEditContactDialog(false);
+      setContactsFeedback({ type: 'success', message: `${trimmedName} updated successfully` });
 
     } catch (error) {
       console.error('Error updating contact:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to update contact';
       setError(errorMessage);
+      setContactsFeedback({ type: 'error', message: errorMessage });
     }
   };
 
@@ -1597,16 +1652,28 @@ export default function MassTextPage() {
               </CardHeader>
               <CardContent>
                 <div className="grid gap-4">
-                  <div className="flex justify-between items-center mb-2">
+                  {contactsFeedback && (
+                    <Alert variant={contactsFeedback.type === 'error' ? 'destructive' : 'default'}>
+                      {contactsFeedback.type === 'error' ? (
+                        <AlertCircle className="h-4 w-4" />
+                      ) : (
+                        <CheckCircle2 className="h-4 w-4" />
+                      )}
+                      <AlertDescription>{contactsFeedback.message}</AlertDescription>
+                    </Alert>
+                  )}
+                  <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
                     <label className="block text-sm font-medium">
-                      Members ({originalContacts.length})
+                      Members ({filteredContacts.length}
+                      {filteredContacts.length !== originalContacts.length && ` of ${originalContacts.length}`})
                     </label>
-                    <div className="flex space-x-2">
+                    <div className="flex flex-wrap gap-2">
                       <Button
                         variant="outline"
                         size="sm"
                         onClick={() => setIsAddingContact(!isAddingContact)}
                       >
+                        <PlusCircleIcon className="h-4 w-4 mr-1" />
                         Add Member
                       </Button>
                       <Button
@@ -1619,6 +1686,45 @@ export default function MassTextPage() {
                         Refresh
                       </Button>
                     </div>
+                  </div>
+
+                  {/* Search + filter controls */}
+                  <div className="flex flex-col md:flex-row gap-2">
+                    <Input
+                      value={contactSearch}
+                      onChange={(e) => setContactSearch(e.target.value)}
+                      placeholder="Search by name, email, or phone..."
+                      className="md:flex-1"
+                    />
+                    <select
+                      value={contactStatusFilter}
+                      onChange={(e) => setContactStatusFilter(e.target.value as 'all' | 'active' | 'opted-out')}
+                      className="border rounded-md px-3 py-2 text-sm bg-white"
+                    >
+                      <option value="all">All statuses</option>
+                      <option value="active">Active only</option>
+                      <option value="opted-out">Opted out only</option>
+                    </select>
+                    <select
+                      value={contactSortBy}
+                      onChange={(e) => setContactSortBy(e.target.value as 'name' | 'recent')}
+                      className="border rounded-md px-3 py-2 text-sm bg-white"
+                    >
+                      <option value="name">Sort by name</option>
+                      <option value="recent">Sort by recent</option>
+                    </select>
+                    {(contactSearch || contactStatusFilter !== 'all') && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setContactSearch("")
+                          setContactStatusFilter('all')
+                        }}
+                      >
+                        Clear
+                      </Button>
+                    )}
                   </div>
 
                   {isAddingContact && (
@@ -1687,162 +1793,108 @@ export default function MassTextPage() {
                               No members found. Add some members to get started.
                             </td>
                           </tr>
+                        ) : filteredContacts.length === 0 ? (
+                          <tr>
+                            <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                              No members match your current filters.
+                            </td>
+                          </tr>
                         ) : (
-                          originalContacts.map((contact, index) => (
+                          filteredContacts.map((contact) => (
                             <tr
-                              key={`contact-${index}`}
+                              key={`contact-${contact.id ?? contact.phone}`}
                               className={`${contact.opted_out ? 'bg-yellow-50' : ''} cursor-pointer hover:bg-gray-50 transition-colors`}
                               onClick={() => {
-                                if (!editingContact?.id || editingContact.id !== contact.id) {
-                                  if (contact.id) {
-                                    setSelectedMember(contact)
-                                    setShowProfileDialog(true)
-                                  }
+                                if (contact.id) {
+                                  setSelectedMember(contact)
+                                  setShowProfileDialog(true)
                                 }
                               }}
                             >
                               <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                                {editingContact?.id === contact.id ? (
-                                  <Input
-                                    value={editingContact?.name || ""}
-                                    onChange={(e) => {
-                                      if (editingContact) {
-                                        setEditingContact({
-                                          ...editingContact,
-                                          name: e.target.value
-                                        });
-                                      }
-                                    }}
-                                  />
+                                {contact.name}
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                {contact.opted_out ? (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span className="inline-flex items-center">
+                                        <AlertTriangleIcon className="h-4 w-4 mr-1 text-yellow-500" />
+                                        <span className="line-through text-yellow-600">{contact.phone}</span>
+                                      </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>This contact has opted out of messages</p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 ) : (
-                                  contact.name
+                                  contact.phone
                                 )}
                               </td>
                               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                {editingContact?.id === contact.id ? (
-                                  <Input
-                                    value={editingContact?.phone || ""}
-                                    onChange={(e) => {
-                                      if (editingContact) {
-                                        setEditingContact({
-                                          ...editingContact,
-                                          phone: e.target.value
-                                        });
+                                {contact.email || "-"}
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                <div className="flex justify-end space-x-2">
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      handleEditContact(contact)
+                                    }}
+                                  >
+                                    <PencilIcon className="h-4 w-4" />
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className={contact.opted_out
+                                      ? "text-green-500 hover:text-green-700"
+                                      : "text-yellow-500 hover:text-yellow-700"}
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      if (contact.id) {
+                                        handleToggleOptOut(contact.id, contact.opted_out || false)
                                       }
                                     }}
-                                  />
-                                ) : (
-                                  <>
-                                    {contact.opted_out && (
+                                  >
+                                    {contact.opted_out ? (
                                       <Tooltip>
                                         <TooltipTrigger asChild>
-                                          <span className="inline-flex items-center">
-                                            <AlertTriangleIcon className="h-4 w-4 mr-1 text-yellow-500" />
-                                            <span className="line-through text-yellow-600">{contact.phone}</span>
+                                          <span className="flex items-center">
+                                            <CheckCircle2 className="h-4 w-4" />
                                           </span>
                                         </TooltipTrigger>
                                         <TooltipContent>
-                                          <p>This contact has opted out of messages</p>
+                                          <p>Opt this contact back in</p>
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    ) : (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <span className="flex items-center">
+                                            <AlertTriangleIcon className="h-4 w-4" />
+                                          </span>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          <p>Mark as opted out</p>
                                         </TooltipContent>
                                       </Tooltip>
                                     )}
-                                    {!contact.opted_out && contact.phone}
-                                  </>
-                                )}
-                              </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                {editingContact?.id === contact.id ? (
-                                  <Input
-                                    value={editingContact?.email || ""}
-                                    onChange={(e) => {
-                                      if (editingContact) {
-                                        setEditingContact({
-                                          ...editingContact,
-                                          email: e.target.value
-                                        });
-                                      }
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="text-red-500 hover:text-red-700"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      handleDeleteContact(contact)
                                     }}
-                                  />
-                                ) : (
-                                  contact.email || "-"
-                                )}
-                              </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                {editingContact?.id === contact.id ? (
-                                  <div className="flex justify-end space-x-2">
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={() => setEditingContact(null)}
-                                    >
-                                      Cancel
-                                    </Button>
-                                    <Button
-                                      size="sm"
-                                      onClick={handleSaveContact}
-                                    >
-                                      Save
-                                    </Button>
-                                  </div>
-                                ) : (
-                                  <div className="flex justify-end space-x-2">
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={(e) => {
-                                        e.stopPropagation()
-                                        handleEditContact(contact)
-                                      }}
-                                    >
-                                      <PencilIcon className="h-4 w-4" />
-                                    </Button>
-                                    <Button
-                                      variant={contact.opted_out ? "outline" : "outline"}
-                                      size="sm"
-                                      className={contact.opted_out
-                                        ? "text-green-500 hover:text-green-700"
-                                        : "text-yellow-500 hover:text-yellow-700"}
-                                      onClick={(e) => {
-                                        e.stopPropagation()
-                                        handleToggleOptOut(contact.id!, contact.opted_out || false)
-                                      }}
-                                    >
-                                      {contact.opted_out
-                                        ? <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <span className="flex items-center">
-                                              <CheckCircle2 className="h-4 w-4" />
-                                            </span>
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            <p>Opt this contact back in</p>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                        : <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <span className="flex items-center">
-                                              <AlertTriangleIcon className="h-4 w-4" />
-                                            </span>
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            <p>Mark as opted out</p>
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      }
-                                    </Button>
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      className="text-red-500 hover:text-red-700"
-                                      onClick={(e) => {
-                                        e.stopPropagation()
-                                        handleDeleteContact(index)
-                                      }}
-                                    >
-                                      <TrashIcon className="h-4 w-4" />
-                                    </Button>
-                                  </div>
-                                )}
+                                  >
+                                    <TrashIcon className="h-4 w-4" />
+                                  </Button>
+                                </div>
                               </td>
                             </tr>
                           ))
@@ -2311,7 +2363,8 @@ export default function MassTextPage() {
             <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
               <h3 className="text-xl font-semibold mb-2">Confirm Delete</h3>
               <p className="text-gray-700 mb-4">
-                Are you sure you want to delete this member? This action cannot be undone.
+                Are you sure you want to delete{' '}
+                <strong>{contactToDelete?.name || 'this member'}</strong>? This action cannot be undone.
               </p>
               <div className="flex justify-end space-x-2">
                 <Button
@@ -2319,6 +2372,7 @@ export default function MassTextPage() {
                   onClick={() => {
                     setIsDeleting(false);
                     setDeletingContactId(null);
+                    setContactToDelete(null);
                   }}
                 >
                   Cancel
@@ -2333,6 +2387,75 @@ export default function MassTextPage() {
             </div>
           </div>
         )}
+
+        {/* Edit contact dialog */}
+        <Dialog
+          open={showEditContactDialog}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShowEditContactDialog(false)
+              setEditingContact(null)
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Edit Member</DialogTitle>
+              <DialogDescription>
+                Update the member&apos;s contact information.
+              </DialogDescription>
+            </DialogHeader>
+            {editingContact && (
+              <div className="grid gap-3 py-2">
+                <div>
+                  <Label htmlFor="edit-contact-name">Name</Label>
+                  <Input
+                    id="edit-contact-name"
+                    value={editingContact.name || ""}
+                    onChange={(e) =>
+                      setEditingContact({ ...editingContact, name: e.target.value })
+                    }
+                    placeholder="John Doe"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="edit-contact-phone">Phone</Label>
+                  <Input
+                    id="edit-contact-phone"
+                    value={editingContact.phone || ""}
+                    onChange={(e) =>
+                      setEditingContact({ ...editingContact, phone: e.target.value })
+                    }
+                    placeholder="+1 (555) 123-4567"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="edit-contact-email">Email</Label>
+                  <Input
+                    id="edit-contact-email"
+                    value={editingContact.email || ""}
+                    onChange={(e) =>
+                      setEditingContact({ ...editingContact, email: e.target.value })
+                    }
+                    placeholder="john.doe@example.com"
+                  />
+                </div>
+              </div>
+            )}
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowEditContactDialog(false)
+                  setEditingContact(null)
+                }}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleSaveContact}>Save Changes</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         {/* Add the flagged contacts confirmation dialog */}
         {showFlaggedContactsDialog && previewData && (

--- a/src/components/ui/EmailBeautifyDialog.tsx
+++ b/src/components/ui/EmailBeautifyDialog.tsx
@@ -73,8 +73,9 @@ interface AIChatInterfaceProps {
   currentMessage: string;
   setCurrentMessage: (message: string) => void;
   isChatLoading: boolean;
-  handleSendChatMessage: () => void;
+  handleSendChatMessage: (overrideMessage?: string) => void;
   chatInputRef: React.RefObject<HTMLInputElement | null>;
+  suggestions: string[];
 }
 
 const AIChatInterface = React.memo(({
@@ -85,7 +86,8 @@ const AIChatInterface = React.memo(({
   setCurrentMessage,
   isChatLoading,
   handleSendChatMessage,
-  chatInputRef
+  chatInputRef,
+  suggestions
 }: AIChatInterfaceProps) => {
   if (!showAIChat) return null;
 
@@ -155,6 +157,24 @@ const AIChatInterface = React.memo(({
           )}
         </div>
 
+        {/* Suggested follow-ups from the AI */}
+        {suggestions.length > 0 && !isChatLoading && (
+          <div className="flex flex-wrap gap-2">
+            {suggestions.map((suggestion, idx) => (
+              <Button
+                key={`${suggestion}-${idx}`}
+                variant="outline"
+                size="sm"
+                className="text-xs h-auto py-1 px-2"
+                onClick={() => handleSendChatMessage(suggestion)}
+                disabled={isChatLoading}
+              >
+                {suggestion}
+              </Button>
+            ))}
+          </div>
+        )}
+
         {/* Chat Input */}
         <div className="flex space-x-2">
           <Input
@@ -174,7 +194,7 @@ const AIChatInterface = React.memo(({
             autoFocus={showAIChat}
           />
           <Button
-            onClick={handleSendChatMessage}
+            onClick={() => handleSendChatMessage()}
             disabled={!currentMessage.trim() || isChatLoading}
             size="sm"
             className="px-3"
@@ -210,6 +230,7 @@ export function EmailBeautifyDialog({
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [currentMessage, setCurrentMessage] = useState('');
   const [isChatLoading, setIsChatLoading] = useState(false);
+  const [chatSuggestions, setChatSuggestions] = useState<string[]>([]);
   const chatInputRef = useRef<HTMLInputElement>(null);
 
   // Load available templates
@@ -228,6 +249,18 @@ export function EmailBeautifyDialog({
 
     if (isOpen) {
       loadTemplates();
+    }
+  }, [isOpen]);
+
+  // Reset chat + beautify state when the dialog closes so the next open starts fresh
+  useEffect(() => {
+    if (!isOpen) {
+      setShowAIChat(false);
+      setChatMessages([]);
+      setCurrentMessage('');
+      setIsChatLoading(false);
+      setChatSuggestions([]);
+      setError(null);
     }
   }, [isOpen]);
 
@@ -296,13 +329,18 @@ export function EmailBeautifyDialog({
     }
   };
 
-  const handleSendChatMessage = useCallback(async () => {
-    if (!currentMessage.trim() || !htmlContent) return;
+  const handleSendChatMessage = useCallback(async (overrideMessage?: string) => {
+    const messageToSend = (overrideMessage ?? currentMessage).trim();
+    if (!messageToSend) return;
+    if (!htmlContent) {
+      setError('Please beautify your email first before using chat.');
+      return;
+    }
 
     const userMessage: ChatMessage = {
       id: Date.now().toString(),
       role: 'user',
-      content: currentMessage,
+      content: messageToSend,
       timestamp: new Date()
     };
 
@@ -310,6 +348,7 @@ export function EmailBeautifyDialog({
     const newHistory = [...chatMessages, userMessage];
     setChatMessages(newHistory);
     setCurrentMessage('');
+    setChatSuggestions([]);
     setIsChatLoading(true);
 
     // Maintain focus on input after clearing message
@@ -324,7 +363,7 @@ export function EmailBeautifyDialog({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          message: currentMessage,
+          message: messageToSend,
           conversationHistory: newHistory.map(m => ({
             role: m.role,
             content: m.content
@@ -339,7 +378,8 @@ export function EmailBeautifyDialog({
       });
 
       if (!response.ok) {
-        throw new Error('Failed to get AI response');
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData?.message || `Failed to get AI response (${response.status})`);
       }
 
       const data = await response.json();
@@ -347,7 +387,7 @@ export function EmailBeautifyDialog({
       const assistantMessage: ChatMessage = {
         id: (Date.now() + 1).toString(),
         role: 'assistant',
-        content: data.message, // Use the conversational response
+        content: data.message || 'Here are the changes.',
         timestamp: new Date()
       };
 
@@ -359,10 +399,11 @@ export function EmailBeautifyDialog({
         setPreviewKey(prev => prev + 1);
       }
 
-      // Handle suggestions if needed (could be appended to chat or shown in UI)
-      // For now we just log them or rely on the message.
-      if (data.suggestions && data.suggestions.length > 0) {
-        console.log('AI Suggestions:', data.suggestions);
+      // Surface suggestions in the UI as quick-reply chips
+      if (Array.isArray(data.suggestions)) {
+        setChatSuggestions(data.suggestions.slice(0, 3));
+      } else {
+        setChatSuggestions([]);
       }
 
     } catch (error) {
@@ -370,7 +411,9 @@ export function EmailBeautifyDialog({
       const errorMessage: ChatMessage = {
         id: (Date.now() + 1).toString(),
         role: 'assistant',
-        content: 'Sorry, I encountered an error. Please try again.',
+        content: error instanceof Error
+          ? `Sorry, I encountered an error: ${error.message}. Please try again.`
+          : 'Sorry, I encountered an error. Please try again.',
         timestamp: new Date()
       };
       setChatMessages(prev => [...prev, errorMessage]);
@@ -558,6 +601,7 @@ export function EmailBeautifyDialog({
               isChatLoading={isChatLoading}
               handleSendChatMessage={handleSendChatMessage}
               chatInputRef={chatInputRef}
+              suggestions={chatSuggestions}
             />
 
             <EnhancementsSummary />


### PR DESCRIPTION
## Summary

Addresses user feedback that editing, filtering, and deleting contacts didn't work, that the email Beautify feature needed updating, and that the AI chat inside the beautify dialog was non-functional.

### Contacts management (`src/app/mass-text/page.tsx`)

- **Search + filter**: Added a search box (matches name / email / phone), a status filter (All / Active / Opted-out), and a sort dropdown (by name or most recent) above the members table. The header now shows `X of Y` members when filters are active, plus a Clear button.
- **Edit works reliably**: Replaced the cramped inline row-editing (which clashed with the row's profile-dialog click handler) with a proper `Dialog`-based edit modal. Edits now validate that name/phone are non-empty and report clear errors.
- **Delete UX**: The delete confirmation now shows the member's name (`Are you sure you want to delete Jane Doe?`) instead of generic text, and a success/error alert appears on the page after the action completes.
- **Feedback banner**: Success/error alerts auto-dismiss after a few seconds so users know their add/edit/delete actually went through.

### Beautify (`src/app/api/email-beautify/route.ts`)

- Enabled OpenAI JSON mode (`response_format: { type: "json_object" }`) so the beautification API reliably returns parseable JSON instead of occasionally breaking with markdown-wrapped output.
- Rewrote the parse-failure fallback: instead of collapsing the message into flat `<p>` tags, it now preserves paragraph boundaries and promotes a short opening line to an `<h2>` so the templated HTML still looks beautified even when the AI response is malformed.

### Chat (`src/components/ui/EmailBeautifyDialog.tsx`)

- Chat/beautify state (messages, input, loading, suggestions, errors) now resets when the dialog closes — reopening it no longer shows a stale conversation.
- AI follow-up suggestions are now rendered as clickable chips below the chat, and clicking one sends it as the next message. Previously they were only `console.log`'d.
- The chat handler accepts an override message (used by the suggestion chips) and surfaces the actual API error text to the user instead of a generic "Sorry" line.

## Test plan

- [ ] Open **All Members** → verify the member count and list render.
- [ ] Type in the search box → list filters by name/email/phone.
- [ ] Change the status filter to *Opted out only* / *Active only* → list updates accordingly.
- [ ] Change sort to *Sort by recent* → most-recently added members appear first.
- [ ] Click the pencil icon on a member → edit dialog opens pre-filled; change the name, click Save → list refreshes and success alert appears.
- [ ] Click the trash icon → confirmation dialog shows the member's name; confirm → member disappears and success alert appears.
- [ ] Compose an email, click **Beautify Email** → preview renders with AI styling; close and reopen → dialog state is fresh.
- [ ] Inside the beautify dialog, open **AI Chat**, ask "Make the header purple" → HTML updates and suggestion chips appear. Click a suggestion chip → it's sent automatically.
- [ ] Disable network / break the AI response → chat shows a specific error message instead of a generic failure.

https://claude.ai/code/session_01PdFoWzFVw7UMSdjGaFu2Ps