### PR TITLE
Fix Members tab: visible delete button and unclipped long rows

### DIFF
--- a/src/app/mass-text/page.tsx
+++ b/src/app/mass-text/page.tsx
@@ -1093,7 +1093,7 @@ export default function MassTextPage() {
 
   return (
     <AnimatedBackground>
-      <div className="container mx-auto p-4 max-w-4xl">
+      <div className={`container mx-auto p-4 ${viewMode === 'contacts-management' ? 'max-w-6xl' : 'max-w-4xl'}`}>
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold">Mass Communication</h1>
           <div className="flex space-x-2">
@@ -1776,26 +1776,26 @@ export default function MassTextPage() {
                   )}
 
                   {/* Contact listing with edit/delete controls */}
-                  <div className="border rounded-md overflow-hidden">
-                    <table className="min-w-full divide-y divide-gray-200">
+                  <div className="border rounded-md overflow-x-auto">
+                    <table className="min-w-[640px] w-full divide-y divide-gray-200 table-auto">
                       <thead className="bg-gray-50">
                         <tr>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-                          <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
+                          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                          <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-[160px]">Actions</th>
                         </tr>
                       </thead>
                       <tbody className="bg-white divide-y divide-gray-200">
                         {originalContacts.length === 0 ? (
                           <tr>
-                            <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                            <td colSpan={4} className="px-4 py-4 text-center text-sm text-gray-500">
                               No members found. Add some members to get started.
                             </td>
                           </tr>
                         ) : filteredContacts.length === 0 ? (
                           <tr>
-                            <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                            <td colSpan={4} className="px-4 py-4 text-center text-sm text-gray-500">
                               No members match your current filters.
                             </td>
                           </tr>
@@ -1803,7 +1803,7 @@ export default function MassTextPage() {
                           filteredContacts.map((contact) => (
                             <tr
                               key={`contact-${contact.id ?? contact.phone}`}
-                              className={`${contact.opted_out ? 'bg-yellow-50' : ''} cursor-pointer hover:bg-gray-50 transition-colors`}
+                              className={`${contact.opted_out ? 'bg-yellow-50' : ''} cursor-pointer hover:bg-gray-50 transition-colors align-top`}
                               onClick={() => {
                                 if (contact.id) {
                                   setSelectedMember(contact)
@@ -1811,10 +1811,10 @@ export default function MassTextPage() {
                                 }
                               }}
                             >
-                              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                              <td className="px-4 py-4 text-sm font-medium text-gray-900 break-words">
                                 {contact.name}
                               </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              <td className="px-4 py-4 text-sm text-gray-500 whitespace-nowrap">
                                 {contact.opted_out ? (
                                   <Tooltip>
                                     <TooltipTrigger asChild>
@@ -1831,69 +1831,75 @@ export default function MassTextPage() {
                                   contact.phone
                                 )}
                               </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              <td className="px-4 py-4 text-sm text-gray-500 break-all">
                                 {contact.email || "-"}
                               </td>
-                              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                              <td className="px-4 py-4 text-right text-sm font-medium w-[160px]">
                                 <div className="flex justify-end space-x-2">
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleEditContact(contact)
-                                    }}
-                                  >
-                                    <PencilIcon className="h-4 w-4" />
-                                  </Button>
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className={contact.opted_out
-                                      ? "text-green-500 hover:text-green-700"
-                                      : "text-yellow-500 hover:text-yellow-700"}
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      if (contact.id) {
-                                        handleToggleOptOut(contact.id, contact.opted_out || false)
-                                      }
-                                    }}
-                                  >
-                                    {contact.opted_out ? (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <span className="flex items-center">
-                                            <CheckCircle2 className="h-4 w-4" />
-                                          </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          <p>Opt this contact back in</p>
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    ) : (
-                                      <Tooltip>
-                                        <TooltipTrigger asChild>
-                                          <span className="flex items-center">
-                                            <AlertTriangleIcon className="h-4 w-4" />
-                                          </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent>
-                                          <p>Mark as opted out</p>
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    )}
-                                  </Button>
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="text-red-500 hover:text-red-700"
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleDeleteContact(contact)
-                                    }}
-                                  >
-                                    <TrashIcon className="h-4 w-4" />
-                                  </Button>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        aria-label="Edit member"
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          handleEditContact(contact)
+                                        }}
+                                      >
+                                        <PencilIcon className="h-4 w-4" />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>Edit member</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        aria-label={contact.opted_out ? 'Opt back in' : 'Mark as opted out'}
+                                        className={contact.opted_out
+                                          ? "text-green-500 hover:text-green-700"
+                                          : "text-yellow-500 hover:text-yellow-700"}
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          if (contact.id) {
+                                            handleToggleOptOut(contact.id, contact.opted_out || false)
+                                          }
+                                        }}
+                                      >
+                                        {contact.opted_out ? (
+                                          <CheckCircle2 className="h-4 w-4" />
+                                        ) : (
+                                          <AlertTriangleIcon className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>{contact.opted_out ? 'Opt this contact back in' : 'Mark as opted out'}</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        aria-label="Delete member"
+                                        className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          handleDeleteContact(contact)
+                                        }}
+                                      >
+                                        <TrashIcon className="h-4 w-4" />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>Delete member</p>
+                                    </TooltipContent>
+                                  </Tooltip>
                                 </div>
                               </td>
                             </tr>


### PR DESCRIPTION
## Summary

Follow-up fix to #17. Users reported two remaining issues in the All Members tab:

1. **Row content is hidden when long** — a member with a long email would push the row wide, and because the table wrapper was `overflow-hidden` the right edge (including the delete button) was clipped off the card.
2. **No visible delete button** — same root cause: the trash-icon Delete button sits in the rightmost Actions column, which was the part being clipped.

## Changes

- Table wrapper is now `overflow-x-auto` (with a `min-w-[640px]` table) so rows scroll horizontally as a fallback when the viewport is narrow.
- Removed `whitespace-nowrap` from the Name / Email cells and added `break-all` to the Email cell so long addresses wrap instead of forcing the row wide in the first place.
- Actions column has a fixed `w-[160px]` width so it never gets squeezed, and each action button now has a tooltip label (Edit / Opt out / Delete) to make them discoverable.
- Contacts-management view uses `max-w-6xl` (1152px) instead of `max-w-4xl` (896px) so the table has more breathing room; the compose view keeps its narrower width.

Both before-wrap and after-scroll behaviors mean the delete button is always reachable.

## Test plan

- [ ] Open **All Members** → every row shows Name, Phone, Email, and three action icons (pencil / warning / trash).
- [ ] Add or view a member with a very long email (`verylongemailaddress@somelongdomainexample.edu`) → email wraps inside its column, no clipping, all three action buttons still visible on the right.
- [ ] On a narrow viewport (mobile), horizontally scroll the table → Actions column is reachable at the right.
- [ ] Hover each action icon → tooltip shows Edit / Mark as opted out / Delete.
- [ ] Click the trash icon → delete confirmation dialog appears with the member's name; confirm → member is removed.

https://claude.ai/code/session_01PdFoWzFVw7UMSdjGaFu2Ps