### PR TITLE
Redesign UI and migrate AI routes from OpenAI to Gemini

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,15 +22,16 @@
         "combined-stream": "^1.0.8",
         "csv-parse": "^5.6.0",
         "delayed-stream": "^1.0.0",
+        "exceljs": "^4.4.0",
         "form-data": "^4.0.2",
         "framer-motion": "^12.7.3",
         "googleapis": "^148.0.0",
-        "jspdf": "^3.0.1",
+        "jspdf": "^4.0.0",
         "lucide-react": "^0.488.0",
         "mammoth": "^1.9.0",
-        "next": "^15.3.1",
+        "next": "15.5.9",
         "next-themes": "^0.4.6",
-        "nodemailer": "^6.10.1",
+        "nodemailer": "^7.0.12",
         "openai": "^4.95.1",
         "pdf-lib": "^1.17.1",
         "qrcode": "^1.5.4",
@@ -44,7 +45,6 @@
         "twilio": "^4.22.0",
         "util": "^0.12.5",
         "web-push": "^3.6.7",
-        "xlsx": "^0.18.5",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -55,7 +55,7 @@
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
-        "eslint-config-next": "15.3.0",
+        "eslint-config-next": "15.5.9",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.4",
         "ts-node": "^10.9.2",
@@ -68,11 +68,11 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
-    "@babel/runtime": ["@babel/runtime@7.27.1", "", {}, "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog=="],
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.4.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
 
@@ -91,6 +91,10 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.8", "", { "dependencies": { "@eslint/core": "^0.13.0", "levn": "^0.4.1" } }, "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA=="],
+
+    "@fast-csv/format": ["@fast-csv/format@4.3.5", "", { "dependencies": { "@types/node": "^14.0.1", "lodash.escaperegexp": "^4.1.2", "lodash.isboolean": "^3.0.3", "lodash.isequal": "^4.5.0", "lodash.isfunction": "^3.0.9", "lodash.isnil": "^4.0.0" } }, "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A=="],
+
+    "@fast-csv/parse": ["@fast-csv/parse@4.3.6", "", { "dependencies": { "@types/node": "^14.0.1", "lodash.escaperegexp": "^4.1.2", "lodash.groupby": "^4.6.0", "lodash.isfunction": "^3.0.9", "lodash.isnil": "^4.0.0", "lodash.isundefined": "^3.0.1", "lodash.uniq": "^4.5.0" } }, "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.9" } }, "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA=="],
 
@@ -112,45 +116,55 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.1.0" }, "os": "darwin", "cpu": "arm64" }, "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A=="],
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.1.0" }, "os": "darwin", "cpu": "x64" }, "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.1.0" }, "os": "linux", "cpu": "arm" }, "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.1.0" }, "os": "linux", "cpu": "s390x" }, "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.1.0" }, "os": "linux", "cpu": "arm64" }, "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.1", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.1.0" }, "os": "linux", "cpu": "x64" }, "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.1", "", { "dependencies": { "@emnapi/runtime": "^1.4.0" }, "cpu": "none" }, "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.1", "", { "os": "win32", "cpu": "x64" }, "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
@@ -168,25 +182,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.9", "", { "dependencies": { "@emnapi/core": "^1.4.0", "@emnapi/runtime": "^1.4.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg=="],
 
-    "@next/env": ["@next/env@15.3.2", "", {}, "sha512-xURk++7P7qR9JG1jJtLzPzf0qEvqCN0A/T3DXf8IPMKo9/6FfjxtEffRJIIew/bIL4T3C2jLLqBor8B/zVlx6g=="],
+    "@next/env": ["@next/env@15.5.9", "", {}, "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.3.0", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-511UUcpWw5GWTyKfzW58U2F/bYJyjLE9e3SlnGK/zSXq7RqLlqFO8B9bitJjumLpj317fycC96KZ2RZsjGNfBw=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.5.9", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2DR6kY/OGcokbnCsjHpNeQblqCZ85/1j6njYSkzRdpLn5At7OkSdmk7WyAmB9G0k25+VgqVZ/u356OSoQZ3z0g=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ro/fdqaZWL6k1S/5CLv1I0DaZfDVJkWNaUU3un8Lg6m0YENWlDulmIWzV96Iou2wEYyEsZq51mwV8+XQXqMp3w=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-covwwtZYhlbRWK2HlYX9835qXum4xYZ3E2Mra1mdQ+0ICGoMiw1+nVAn4d9Bo7R3JqSmK1grMq/va+0cdh7bJA=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-KQkMEillvlW5Qk5mtGA/3Yz0/tzpNlSw6/3/ttsV1lNtMuOHcGii3zVeXZyi4EJmmLDKYcTcByV2wVsOhDt/zg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uRBo6THWei0chz+Y5j37qzx+BtoDRFIkDzZjlpCItBRXyMPIg079eIkOCl3aqr2tkxL4HFyJ4GHDes7W8HuAUg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-+uxFlPuCNx/T9PdMClOqeE8USKzj8tVz37KflT3Kdbx/LOlZBRI2yxuIcmx1mPNK8DwSOMNCr4ureSet7eyC0w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LLTKmaI5cfD8dVzh5Vt7+OMo+AIOClEdIU/TSKbXXT2iScUTSxOGoBhfuv+FU8R9MLmrkIL1e2fBMkEEjYAtPQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-aW5B8wOPioJ4mBdMDXkt5f3j8pUr9W8AnlX0Df35uRWNT1Y6RIybxjnSUe+PhM+M1bwgyY8PHLmXZC6zT1o5tA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -290,8 +304,6 @@
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.49.4", "", { "dependencies": { "@supabase/auth-js": "2.69.1", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.2", "@supabase/storage-js": "2.7.1" } }, "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw=="],
 
-    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
-
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.6", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "enhanced-resolve": "^5.18.1", "jiti": "^2.4.2", "lightningcss": "1.29.2", "magic-string": "^0.30.17", "source-map-js": "^1.2.1", "tailwindcss": "4.1.6" } }, "sha512-ed6zQbgmKsjsVvodAS1q1Ld2BolEuxJOSyyNc+vhkjdmfNUDCmQnlXBfQkHrlzNmslxHsQU/bFmzcEbv4xXsLg=="],
@@ -343,6 +355,8 @@
     "@types/node-fetch": ["@types/node-fetch@2.6.12", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA=="],
 
     "@types/nodemailer": ["@types/nodemailer@6.4.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww=="],
+
+    "@types/pako": ["@types/pako@2.0.4", "", {}, "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="],
 
     "@types/phoenix": ["@types/phoenix@1.6.6", "", {}, "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="],
 
@@ -418,8 +432,6 @@
 
     "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
 
-    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
-
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
@@ -429,6 +441,10 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "archiver": ["archiver@5.3.2", "", { "dependencies": { "archiver-utils": "^2.1.0", "async": "^3.2.4", "buffer-crc32": "^0.2.1", "readable-stream": "^3.6.0", "readdir-glob": "^1.1.2", "tar-stream": "^2.2.0", "zip-stream": "^4.1.0" } }, "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw=="],
+
+    "archiver-utils": ["archiver-utils@2.1.0", "", { "dependencies": { "glob": "^7.1.4", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^2.0.0" } }, "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw=="],
 
     "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
@@ -458,11 +474,11 @@
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
-    "atob": ["atob@2.1.2", "", { "bin": { "atob": "bin/atob.js" } }, "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="],
 
     "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
 
@@ -480,7 +496,13 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
+
     "bignumber.js": ["bignumber.js@9.3.0", "", {}, "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA=="],
+
+    "binary": ["binary@0.3.0", "", { "dependencies": { "buffers": "~0.1.1", "chainsaw": "~0.1.0" } }, "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
@@ -494,11 +516,15 @@
 
     "browserslist": ["browserslist@4.24.5", "", { "dependencies": { "caniuse-lite": "^1.0.30001716", "electron-to-chromium": "^1.5.149", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw=="],
 
-    "btoa": ["btoa@1.2.1", "", { "bin": { "btoa": "bin/btoa.js" } }, "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="],
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
+    "buffer-indexof-polyfill": ["buffer-indexof-polyfill@1.0.2", "", {}, "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="],
+
+    "buffers": ["buffers@0.1.1", "", {}, "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -516,7 +542,7 @@
 
     "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
-    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+    "chainsaw": ["chainsaw@0.1.0", "", { "dependencies": { "traverse": ">=0.3.0 <0.4" } }, "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -530,17 +556,13 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
-
-    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
-
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "compress-commons": ["compress-commons@4.1.2", "", { "dependencies": { "buffer-crc32": "^0.2.13", "crc32-stream": "^4.0.2", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -559,6 +581,8 @@
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
+
+    "crc32-stream": ["crc32-stream@4.0.3", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^3.4.0" } }, "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw=="],
 
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
@@ -606,11 +630,13 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dompurify": ["dompurify@3.2.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ=="],
+    "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
 
     "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
@@ -621,6 +647,8 @@
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg=="],
 
@@ -648,7 +676,7 @@
 
     "eslint": ["eslint@9.26.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.20.0", "@eslint/config-helpers": "^0.2.1", "@eslint/core": "^0.13.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.26.0", "@eslint/plugin-kit": "^0.2.8", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@modelcontextprotocol/sdk": "^1.8.0", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.3.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "zod": "^3.24.2" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ=="],
 
-    "eslint-config-next": ["eslint-config-next@15.3.0", "", { "dependencies": { "@next/eslint-plugin-next": "15.3.0", "@rushstack/eslint-patch": "^1.10.3", "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.31.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^5.0.0" }, "peerDependencies": { "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-+Z3M1W9MnJjX3W4vI9CHfKlEyhTWOUHvc5dB89FyRnzPsUkJlLWZOi8+1pInuVcSztSM4MwBFB0hIHf4Rbwu4g=="],
+    "eslint-config-next": ["eslint-config-next@15.5.9", "", { "dependencies": { "@next/eslint-plugin-next": "15.5.9", "@rushstack/eslint-patch": "^1.10.3", "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.31.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^5.0.0" }, "peerDependencies": { "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-852JYI3NkFNzW8CqsMhI0K2CDRxTObdZ2jQJj5CtpEaOkYHn13107tHpNuD/h0WRpU4FAbCdUaxQsrfBtNK9Kw=="],
 
     "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
 
@@ -686,11 +714,15 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.1", "", {}, "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA=="],
 
+    "exceljs": ["exceljs@4.4.0", "", { "dependencies": { "archiver": "^5.0.0", "dayjs": "^1.8.34", "fast-csv": "^4.3.1", "jszip": "^3.10.1", "readable-stream": "^3.6.0", "saxes": "^5.0.1", "tmp": "^0.2.0", "unzipper": "^0.10.11", "uuid": "^8.3.0" } }, "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg=="],
+
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.0", "", { "peerDependencies": { "express": "^4.11 || 5 || ^5.0.0-beta.1" } }, "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-csv": ["fast-csv@4.3.6", "", { "dependencies": { "@fast-csv/format": "4.3.5", "@fast-csv/parse": "4.3.6" } }, "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -699,6 +731,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-png": ["fast-png@6.4.0", "", { "dependencies": { "@types/pako": "^2.0.3", "iobuffer": "^5.3.2", "pako": "^2.1.0" } }, "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -730,13 +764,17 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
-    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
-
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
 
     "framer-motion": ["framer-motion@12.11.0", "", { "dependencies": { "motion-dom": "^12.11.0", "motion-utils": "^12.9.4", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-BaBPmkhaC2l0n619Kt1nQaxSdUdyyz5V1Z7EKJ1CcraOTZitgVx0RTbL8lmg2XesaFi6o8MPBIhkWDIvzDpGaQ=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "fstream": ["fstream@1.0.12", "", { "dependencies": { "graceful-fs": "^4.1.2", "inherits": "~2.0.0", "mkdirp": ">=0.5 0", "rimraf": "2" } }, "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -759,6 +797,8 @@
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.10.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A=="],
+
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -808,6 +848,8 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
@@ -816,17 +858,19 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
-
-    "is-arrayish": ["is-arrayish@0.3.2", "", {}, "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="],
 
     "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
 
@@ -906,7 +950,7 @@
 
     "jsonwebtoken": ["jsonwebtoken@9.0.2", "", { "dependencies": { "jws": "^3.2.2", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ=="],
 
-    "jspdf": ["jspdf@3.0.1", "", { "dependencies": { "@babel/runtime": "^7.26.7", "atob": "^2.1.2", "btoa": "^1.2.1", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.2.4", "html2canvas": "^1.0.0-rc.5" } }, "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg=="],
+    "jspdf": ["jspdf@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -921,6 +965,8 @@
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
+
+    "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -948,7 +994,19 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.29.2", "", { "os": "win32", "cpu": "x64" }, "sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA=="],
 
+    "listenercount": ["listenercount@1.0.1", "", {}, "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.difference": ["lodash.difference@4.5.0", "", {}, "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="],
+
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.flatten": ["lodash.flatten@4.4.0", "", {}, "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="],
+
+    "lodash.groupby": ["lodash.groupby@4.6.0", "", {}, "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="],
 
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 
@@ -956,7 +1014,11 @@
 
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
+    "lodash.isfunction": ["lodash.isfunction@3.0.9", "", {}, "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="],
+
     "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnil": ["lodash.isnil@4.0.0", "", {}, "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="],
 
     "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
 
@@ -964,9 +1026,15 @@
 
     "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
 
+    "lodash.isundefined": ["lodash.isundefined@3.0.1", "", {}, "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="],
+
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
+
+    "lodash.union": ["lodash.union@4.6.0", "", {}, "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="],
+
+    "lodash.uniq": ["lodash.uniq@4.5.0", "", {}, "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -1020,7 +1088,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@15.3.2", "", { "dependencies": { "@next/env": "15.3.2", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.2", "@next/swc-darwin-x64": "15.3.2", "@next/swc-linux-arm64-gnu": "15.3.2", "@next/swc-linux-arm64-musl": "15.3.2", "@next/swc-linux-x64-gnu": "15.3.2", "@next/swc-linux-x64-musl": "15.3.2", "@next/swc-win32-arm64-msvc": "15.3.2", "@next/swc-win32-x64-msvc": "15.3.2", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ=="],
+    "next": ["next@15.5.9", "", { "dependencies": { "@next/env": "15.5.9", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.7", "@next/swc-darwin-x64": "15.5.7", "@next/swc-linux-arm64-gnu": "15.5.7", "@next/swc-linux-arm64-musl": "15.5.7", "@next/swc-linux-x64-gnu": "15.5.7", "@next/swc-linux-x64-musl": "15.5.7", "@next/swc-win32-arm64-msvc": "15.5.7", "@next/swc-win32-x64-msvc": "15.5.7", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1030,7 +1098,9 @@
 
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
-    "nodemailer": ["nodemailer@6.10.1", "", {}, "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="],
+    "nodemailer": ["nodemailer@7.0.13", "", {}, "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
 
@@ -1148,6 +1218,8 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
@@ -1170,6 +1242,8 @@
 
     "rgbcolor": ["rgbcolor@1.0.1", "", {}, "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw=="],
 
+    "rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -1183,6 +1257,8 @@
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@5.0.1", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
@@ -1206,7 +1282,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "sharp": ["sharp@0.34.1", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.7.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.1", "@img/sharp-darwin-x64": "0.34.1", "@img/sharp-libvips-darwin-arm64": "1.1.0", "@img/sharp-libvips-darwin-x64": "1.1.0", "@img/sharp-libvips-linux-arm": "1.1.0", "@img/sharp-libvips-linux-arm64": "1.1.0", "@img/sharp-libvips-linux-ppc64": "1.1.0", "@img/sharp-libvips-linux-s390x": "1.1.0", "@img/sharp-libvips-linux-x64": "1.1.0", "@img/sharp-libvips-linuxmusl-arm64": "1.1.0", "@img/sharp-libvips-linuxmusl-x64": "1.1.0", "@img/sharp-linux-arm": "0.34.1", "@img/sharp-linux-arm64": "0.34.1", "@img/sharp-linux-s390x": "0.34.1", "@img/sharp-linux-x64": "0.34.1", "@img/sharp-linuxmusl-arm64": "0.34.1", "@img/sharp-linuxmusl-x64": "0.34.1", "@img/sharp-wasm32": "0.34.1", "@img/sharp-win32-ia32": "0.34.1", "@img/sharp-win32-x64": "0.34.1" } }, "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg=="],
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1220,13 +1296,9 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "simple-swizzle": ["simple-swizzle@0.2.2", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
@@ -1235,8 +1307,6 @@
     "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
-
-    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1276,15 +1346,21 @@
 
     "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
 
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
     "tinyglobby": ["tinyglobby@0.2.13", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw=="],
+
+    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "traverse": ["traverse@0.3.9", "", {}, "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
@@ -1322,6 +1398,8 @@
 
     "unrs-resolver": ["unrs-resolver@1.7.2", "", { "dependencies": { "napi-postinstall": "^0.2.2" }, "optionalDependencies": { "@unrs/resolver-binding-darwin-arm64": "1.7.2", "@unrs/resolver-binding-darwin-x64": "1.7.2", "@unrs/resolver-binding-freebsd-x64": "1.7.2", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.2", "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.2", "@unrs/resolver-binding-linux-arm64-gnu": "1.7.2", "@unrs/resolver-binding-linux-arm64-musl": "1.7.2", "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.2", "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.2", "@unrs/resolver-binding-linux-riscv64-musl": "1.7.2", "@unrs/resolver-binding-linux-s390x-gnu": "1.7.2", "@unrs/resolver-binding-linux-x64-gnu": "1.7.2", "@unrs/resolver-binding-linux-x64-musl": "1.7.2", "@unrs/resolver-binding-wasm32-wasi": "1.7.2", "@unrs/resolver-binding-win32-arm64-msvc": "1.7.2", "@unrs/resolver-binding-win32-ia32-msvc": "1.7.2", "@unrs/resolver-binding-win32-x64-msvc": "1.7.2" } }, "sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A=="],
 
+    "unzipper": ["unzipper@0.10.14", "", { "dependencies": { "big-integer": "^1.6.17", "binary": "~0.3.0", "bluebird": "~3.4.1", "buffer-indexof-polyfill": "~1.0.0", "duplexer2": "~0.1.4", "fstream": "^1.0.12", "graceful-fs": "^4.2.2", "listenercount": "~1.0.1", "readable-stream": "~2.3.6", "setimmediate": "~1.0.4" } }, "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -1340,7 +1418,7 @@
 
     "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
-    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
@@ -1366,10 +1444,6 @@
 
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
 
-    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
-
-    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
-
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
@@ -1378,9 +1452,9 @@
 
     "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
-    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
-
     "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
@@ -1394,15 +1468,19 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
+
     "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
 
     "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@emnapi/runtime/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@fast-csv/format/@types/node": ["@types/node@14.18.63", "", {}, "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="],
+
+    "@fast-csv/parse/@types/node": ["@types/node@14.18.63", "", {}, "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
@@ -1436,6 +1514,12 @@
 
     "accepts/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
+    "archiver-utils/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "canvg/@babel/runtime": ["@babel/runtime@7.27.1", "", {}, "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog=="],
+
+    "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -1448,7 +1532,13 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fast-png/pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
+
     "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "googleapis-common/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "is-bun-module/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
@@ -1460,6 +1550,8 @@
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
@@ -1468,13 +1560,17 @@
 
     "pdf-lib/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "send/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
-    "sharp/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1482,11 +1578,15 @@
 
     "type-is/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
+    "unzipper/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "web-push/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA=="],
 
@@ -1518,6 +1618,14 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "duplexer2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.3", "", {}, "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="],
@@ -1528,11 +1636,21 @@
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "unzipper/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "unzipper/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "web-push/https-proxy-agent/agent-base": ["agent-base@7.1.3", "", {}, "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="],
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,257 +1,203 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { motion } from "framer-motion";
 import Link from "next/link";
 import AnimatedBackground from "@/components/AnimatedBackground";
+import { ArrowLeft, ArrowRight, Mail, Sparkles, FileSpreadsheet, MessageSquare, QrCode, Shield, Users, Calendar } from "lucide-react";
+
+const features = [
+    { icon: Sparkles, title: 'AI column matching', desc: 'Drop in any spreadsheet — Blitz figures out which columns are which.' },
+    { icon: FileSpreadsheet, title: 'CSV & Excel ready', desc: 'Native support for the formats your team already uses.' },
+    { icon: MessageSquare, title: 'SMS + Email together', desc: 'One composer, both channels, deliverability optimized.' },
+    { icon: Users, title: 'Smart contact mgmt', desc: 'Opt-out, deduplication, and tagging — all built-in.' },
+    { icon: QrCode, title: 'QR registration', desc: 'Generate codes for events and member onboarding.' },
+    { icon: Calendar, title: 'Event check-in', desc: 'Track who showed up with QR check-ins and live counts.' },
+];
+
+const audiences = [
+    'Campus organizations & clubs',
+    'Student government bodies',
+    'Small businesses & startups',
+    'Event organizers & venues',
+    'Educational institutions',
+    'Religious & community groups',
+];
 
 export default function AboutPage() {
-  return (
-    <AnimatedBackground>
-      <div className="relative min-h-screen w-full bg-transparent text-black sm:text-black text-white flex flex-col items-center justify-center z-10">
-        <div className="container mx-auto px-4 py-16">
-          <motion.div 
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            className="max-w-4xl mx-auto space-y-12"
-          >
-            <div className="text-center space-y-6">
-              <motion.h1 
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ duration: 0.8 }}
-                className="text-6xl md:text-8xl font-bold tracking-tight relative"
-              >
-                <div className="relative">
-                  <span className="bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent animate-gradient">
-                    About Us
-                  </span>
-                </div>
-              </motion.h1>
-              <motion.p 
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.3, duration: 0.8 }}
-                className="text-xl md:text-2xl font-semibold max-w-2xl mx-auto leading-relaxed bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent animate-gradient"
-                style={{
-                  WebkitBackgroundClip: 'text',
-                  backgroundClip: 'text',
-                  color: 'transparent',
-                  WebkitTextFillColor: 'transparent',
-                  MozBackgroundClip: 'text',
-                }}
-              >
-                The Ultimate Communication Platform for Organizations
-              </motion.p>
-            </div>
+    return (
+        <AnimatedBackground variant="hero">
+            <div className="relative z-10 mx-auto w-full max-w-5xl px-6 py-12 sm:py-16">
+                <Link
+                    href="/"
+                    className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    Back to home
+                </Link>
 
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.4, duration: 0.8 }}
-            >
-              <Card className="bg-white/5 backdrop-blur-sm border-white/10">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">What We Offer</CardTitle>
-                  <CardDescription className="text-base text-gray-700">
-                    A powerful, all-in-one platform for seamless mass communication
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <p className="text-base text-gray-700">
-                    Blitz is a communication platform that combines the power of mass texting and email capabilities in one intuitive interface. Perfect for campus organizations, clubs, and businesses, our platform streamlines your communication needs with cutting-edge features and user-friendly design. Built with modern technology and a focus on user experience, we make mass communication simple and effective.
-                  </p>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            <div className="grid md:grid-cols-2 gap-6">
-              <motion.div
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.5, duration: 0.8 }}
-              >
-                <Card className="bg-white/5 backdrop-blur-sm border-white/10 h-full">
-                  <CardHeader>
-                    <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">Key Features</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <ul className="space-y-3 text-base text-gray-700">
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Intelligent file upload with AI-powered column matching</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Support for Excel and CSV files</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Unified platform for both SMS and email</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Smart contact management with opt-out handling</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>QR code-based member registration</span>
-                      </li>
-                    </ul>
-                  </CardContent>
-                </Card>
-              </motion.div>
-
-              <motion.div
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.6, duration: 0.8 }}
-              >
-                <Card className="bg-white/5 backdrop-blur-sm border-white/10 h-full">
-                  <CardHeader>
-                    <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">Perfect For</CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <ul className="space-y-3 text-base text-gray-700">
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Campus organizations and clubs</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Student government bodies</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Small businesses and startups</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Event organizers</span>
-                      </li>
-                      <li className="flex items-center space-x-2">
-                        <span className="w-2 h-2 bg-purple-600 rounded-full"></span>
-                        <span>Educational institutions</span>
-                      </li>
-                    </ul>
-                  </CardContent>
-                </Card>
-              </motion.div>
-            </div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.7, duration: 0.8 }}
-            >
-              <Card className="bg-white/5 backdrop-blur-sm border-white/10">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">Why Choose Blitz</CardTitle>
-                  <CardDescription className="text-base text-gray-700">
-                    Experience the future of organizational communication
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  <p className="text-base text-gray-700">
-                    Our platform stands out with its intelligent file processing capabilities. Simply upload your Excel or CSV files, and our AI technology automatically matches columns and organizes your contact data. This smart approach saves you time and eliminates manual data entry errors. Whether you&apos;re managing a campus organization, running a business, or coordinating events, Mass Texter provides the tools you need to communicate effectively with your audience.
-                  </p>
-                  <div className="flex justify-center">
-                    <Link
-                      href="/"
-                      className="bg-gradient-to-r from-blue-600 via-purple-500 to-blue-800 text-white px-6 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-purple-600/30 transition-all duration-300 transform hover:scale-105"
-                    >
-                      Get Started Now
-                    </Link>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.75, duration: 0.8 }}
-            >
-              <Card className="bg-white/5 backdrop-blur-sm border-white/10">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">See It In Action</CardTitle>
-                  <CardDescription className="text-base text-gray-700">
-                    Watch our platform in action
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="relative w-full" style={{ paddingTop: '56.25%' }}>
-                    <iframe
-                      src="https://www.loom.com/embed/834c84a07f884f059e370a275fb72071?sid=cc50b005-7f33-4b9d-acef-1dec6712aa47"
-                      allowFullScreen
-                      className="absolute top-0 left-0 w-full h-full rounded-lg shadow-lg"
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.8, duration: 0.8 }}
-            >
-              <Card className="bg-white/5 backdrop-blur-sm border-white/10">
-                <CardHeader>
-                  <CardTitle className="text-xl md:text-2xl bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent">Contact Us</CardTitle>
-                  <CardDescription className="text-base text-gray-700">
-                    Have questions? We&apos;re here to help!
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  <div className="space-y-4">
-                    <p className="text-base text-gray-700">
-                      For any further questions, please email us at:
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6 }}
+                    className="mt-10 text-center"
+                >
+                    <p className="text-xs font-semibold uppercase tracking-wider text-primary">
+                        About Blitz
                     </p>
-                    <a 
-                      href="mailto:arvin@hakakian.me"
-                      className="inline-block text-base font-medium text-purple-600 hover:text-purple-700 transition-colors duration-200"
-                    >
-                      arvin@hakakian.me
-                    </a>
-                  </div>
-                  
-                  <div className="space-y-4">
-                    <p className="text-base text-gray-700">
-                      Connect with us on LinkedIn:
+                    <h1 className="mt-3 text-5xl font-semibold tracking-tighter sm:text-6xl md:text-7xl">
+                        Communication, <br />
+                        <span className="brand-wordmark">simplified.</span>
+                    </h1>
+                    <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+                        Blitz is the all-in-one platform that combines mass texting, email, member management, and event tools — designed for the way modern organizations actually communicate.
                     </p>
-                    <div className="flex flex-col space-y-2">
-                      <a 
-                        href="https://www.linkedin.com/in/arvin-hakakian/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center text-base font-medium text-purple-600 hover:text-purple-700 transition-colors duration-200"
-                      >
-                        <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                        </svg>
-                        Arvin Hakakian
-                      </a>
-                      <a 
-                        href="https://www.linkedin.com/in/eyal-shechtman/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center text-base font-medium text-purple-600 hover:text-purple-700 transition-colors duration-200"
-                      >
-                        <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                        </svg>
-                        Eyal Shechtman
-                      </a>
+                </motion.div>
+
+                <motion.section
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: 0.1 }}
+                    className="mt-16"
+                >
+                    <div className="grid gap-px overflow-hidden rounded-2xl border border-border/80 bg-border/80 sm:grid-cols-2 lg:grid-cols-3">
+                        {features.map((f) => (
+                            <div key={f.title} className="bg-card p-6">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent text-primary">
+                                    <f.icon className="h-5 w-5" />
+                                </div>
+                                <h3 className="mt-4 font-semibold">{f.title}</h3>
+                                <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{f.desc}</p>
+                            </div>
+                        ))}
                     </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          </motion.div>
-        </div>
-      </div>
-    </AnimatedBackground>
-  )
-} 
+                </motion.section>
+
+                <motion.section
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: 0.2 }}
+                    className="mt-16 grid gap-8 lg:grid-cols-2"
+                >
+                    <div className="rounded-2xl border border-border/80 bg-card p-8">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-primary">Built for</p>
+                        <h2 className="mt-3 text-2xl font-semibold tracking-tight">Organizations of every size</h2>
+                        <ul className="mt-6 space-y-3">
+                            {audiences.map((a) => (
+                                <li key={a} className="flex items-start gap-3 text-sm">
+                                    <div className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                                    <span className="text-foreground/90">{a}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div className="rounded-2xl border border-border/80 bg-card p-8">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-primary">Why Blitz</p>
+                        <h2 className="mt-3 text-2xl font-semibold tracking-tight">Less chaos, more clarity</h2>
+                        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+                            We built Blitz because juggling spreadsheets, group chats, and ad-hoc tools was getting in the way of actually doing the work. With AI-powered file parsing, automatic opt-out handling, and a unified inbox of who said what — your team spends less time on logistics and more time on impact.
+                        </p>
+                        <div className="mt-6 flex items-center gap-2 rounded-lg bg-accent/60 p-3 text-xs">
+                            <Shield className="h-4 w-4 text-primary" />
+                            <span className="text-foreground/80">10DLC compliant · Opt-out handling · Per-org rate limits</span>
+                        </div>
+                    </div>
+                </motion.section>
+
+                <motion.section
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: 0.3 }}
+                    className="mt-16"
+                >
+                    <div className="overflow-hidden rounded-2xl border border-border/80 bg-card">
+                        <div className="border-b border-border/80 px-6 py-4">
+                            <h2 className="text-lg font-semibold tracking-tight">See it in action</h2>
+                            <p className="text-sm text-muted-foreground">A two-minute tour of how Blitz works</p>
+                        </div>
+                        <div className="relative w-full" style={{ paddingTop: '56.25%' }}>
+                            <iframe
+                                src="https://www.loom.com/embed/834c84a07f884f059e370a275fb72071?sid=cc50b005-7f33-4b9d-acef-1dec6712aa47"
+                                allowFullScreen
+                                className="absolute top-0 left-0 h-full w-full"
+                            />
+                        </div>
+                    </div>
+                </motion.section>
+
+                <motion.section
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: 0.4 }}
+                    className="mt-16 grid gap-8 sm:grid-cols-2"
+                >
+                    <div className="rounded-2xl border border-border/80 bg-card p-8">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent text-primary">
+                            <Mail className="h-5 w-5" />
+                        </div>
+                        <h2 className="mt-4 text-xl font-semibold tracking-tight">Get in touch</h2>
+                        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                            Have questions, feedback, or just want to say hi? We&apos;d love to hear from you.
+                        </p>
+                        <a
+                            href="mailto:arvin@hakakian.me"
+                            className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                        >
+                            arvin@hakakian.me
+                            <ArrowRight className="h-3.5 w-3.5" />
+                        </a>
+                    </div>
+                    <div className="rounded-2xl border border-border/80 bg-card p-8">
+                        <h2 className="text-xl font-semibold tracking-tight">The team</h2>
+                        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                            Connect with us on LinkedIn.
+                        </p>
+                        <div className="mt-4 space-y-2">
+                            {[
+                                { name: 'Arvin Hakakian', url: 'https://www.linkedin.com/in/arvin-hakakian/' },
+                                { name: 'Eyal Shechtman', url: 'https://www.linkedin.com/in/eyal-shechtman/' },
+                            ].map((p) => (
+                                <a
+                                    key={p.name}
+                                    href={p.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center justify-between rounded-lg border border-border/60 bg-background p-3 transition-colors hover:border-primary/40 hover:bg-accent/50"
+                                >
+                                    <span className="text-sm font-medium">{p.name}</span>
+                                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                </motion.section>
+
+                <motion.section
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: 0.5 }}
+                    className="mt-16"
+                >
+                    <div className="overflow-hidden rounded-2xl border border-border/80 bg-gradient-to-br from-foreground to-foreground/85 px-8 py-12 text-background sm:px-12">
+                        <div className="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-center">
+                            <div>
+                                <h3 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                                    Try Blitz today
+                                </h3>
+                                <p className="mt-2 text-sm text-background/70">
+                                    Free to set up. Cancel anytime.
+                                </p>
+                            </div>
+                            <Link
+                                href="/"
+                                className="inline-flex h-11 items-center gap-2 rounded-xl bg-background px-5 text-sm font-medium text-foreground shadow-lg transition-transform hover:scale-[1.02] active:scale-[0.98]"
+                            >
+                                Get started
+                                <ArrowRight className="h-4 w-4" />
+                            </Link>
+                        </div>
+                    </div>
+                </motion.section>
+            </div>
+        </AnimatedBackground>
+    );
+}

--- a/src/app/access-code/page.tsx
+++ b/src/app/access-code/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from 'next/link';
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, ArrowLeft, KeyRound, Loader2 } from "lucide-react";
 import TransitionAnimation from '@/components/TransitionAnimation';
+import AnimatedBackground from '@/components/AnimatedBackground';
 import { motion } from 'framer-motion';
 
 export default function AccessCodePage() {
@@ -19,7 +20,6 @@ export default function AccessCodePage() {
     const [isVisible, setIsVisible] = useState(false);
 
     useEffect(() => {
-        // Trigger entrance animation after component mounts
         setIsVisible(true);
     }, []);
 
@@ -31,9 +31,7 @@ export default function AccessCodePage() {
         try {
             const response = await fetch('/api/verify-code', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ accessCode }),
             });
 
@@ -41,10 +39,7 @@ export default function AccessCodePage() {
 
             if (response.ok) {
                 setShowTransition(true);
-                // Wait for the transition animation to complete before redirecting
-                setTimeout(() => {
-                    router.push('/mass-text');
-                }, 1000);
+                setTimeout(() => router.push('/mass-text'), 1000);
             } else {
                 setError(data.message || 'Invalid access code');
                 setIsLoading(false);
@@ -58,62 +53,79 @@ export default function AccessCodePage() {
     return (
         <>
             {showTransition && <TransitionAnimation />}
-            <motion.div 
-                className="min-h-screen flex items-center justify-center bg-gradient-to-b from-gray-900 to-black p-4"
-                initial={{ opacity: 0 }}
-                animate={{ 
-                    opacity: isVisible ? 1 : 0,
-                }}
-                transition={{ duration: 0.8, ease: "easeOut" }}
-            >
-                <motion.div
-                    initial={{ scale: 0.95, opacity: 0, y: 20 }}
-                    animate={{ 
-                        scale: isVisible ? 1 : 0.95,
-                        opacity: isVisible ? 1 : 0,
-                        y: isVisible ? 0 : 20
-                    }}
-                    transition={{ 
-                        duration: 0.8, 
-                        delay: 0.3,
-                        ease: [0.16, 1, 0.3, 1] // Custom easing for a more polished feel
-                    }}
-                >
-                    <Card className="w-full max-w-md backdrop-blur-sm bg-white/90 shadow-xl">
-                        <CardHeader>
-                            <CardTitle className="text-2xl text-center">Enter Access Code</CardTitle>
-                            <CardDescription className="text-center">
-                                Please enter your organization&apos;s access code to continue
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                            <form onSubmit={handleSubmit} className="space-y-4">
-                                <Input
-                                    type="password"
-                                    placeholder="Enter access code"
-                                    value={accessCode}
-                                    onChange={(e) => setAccessCode(e.target.value)}
-                                    className="w-full"
-                                    required
-                                />
+            <AnimatedBackground variant="hero">
+                <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center px-6">
+                    <Link
+                        href="/"
+                        className="absolute left-6 top-6 inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    >
+                        <ArrowLeft className="h-4 w-4" />
+                        Home
+                    </Link>
+
+                    <motion.div
+                        initial={{ opacity: 0, y: 20, scale: 0.98 }}
+                        animate={{
+                            opacity: isVisible ? 1 : 0,
+                            y: isVisible ? 0 : 20,
+                            scale: isVisible ? 1 : 0.98,
+                        }}
+                        transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+                        className="w-full"
+                    >
+                        <div className="rounded-2xl border border-border/80 bg-card/90 p-8 shadow-elevated backdrop-blur-xl">
+                            <div className="flex items-center justify-center">
+                                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                                    <KeyRound className="h-6 w-6" />
+                                </div>
+                            </div>
+                            <h1 className="mt-5 text-center text-2xl font-semibold tracking-tight">
+                                Enter access code
+                            </h1>
+                            <p className="mt-2 text-center text-sm text-muted-foreground">
+                                Enter your organization&apos;s access code to continue.
+                            </p>
+
+                            <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+                                <div>
+                                    <Input
+                                        type="password"
+                                        placeholder="••••••••"
+                                        value={accessCode}
+                                        onChange={(e) => setAccessCode(e.target.value)}
+                                        className="h-11 text-center text-base tracking-[0.3em]"
+                                        autoFocus
+                                        required
+                                    />
+                                </div>
                                 {error && (
                                     <Alert variant="destructive">
                                         <AlertCircle className="h-4 w-4" />
                                         <AlertDescription>{error}</AlertDescription>
                                     </Alert>
                                 )}
-                                <Button 
-                                    type="submit" 
-                                    className="w-full"
-                                    disabled={isLoading}
-                                >
-                                    {isLoading ? 'Verifying...' : 'Continue'}
+                                <Button type="submit" size="lg" className="w-full" disabled={isLoading}>
+                                    {isLoading ? (
+                                        <>
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                            Verifying...
+                                        </>
+                                    ) : (
+                                        'Continue'
+                                    )}
                                 </Button>
                             </form>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </motion.div>
+                        </div>
+
+                        <p className="mt-6 text-center text-sm text-muted-foreground">
+                            Don&apos;t have an organization yet?{' '}
+                            <Link href="/register" className="font-medium text-primary hover:underline">
+                                Register one
+                            </Link>
+                        </p>
+                    </motion.div>
+                </div>
+            </AnimatedBackground>
         </>
     );
-} 
+}

--- a/src/app/api/ai-assist/route.ts
+++ b/src/app/api/ai-assist/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
 
 export async function POST(request: NextRequest) {
   try {
@@ -106,21 +103,18 @@ Only include updatedHtml and updatedEnhancements if you actually made changes. I
       }
     }
     
-    // Call OpenAI API
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        { 
-          role: "system", 
-          content: systemMessage
-        },
-        { role: "user", content: prompt }
-      ],
-      temperature: 0.7,
-      max_tokens: type === 'email_customization' ? 2000 : 500,
+    const model = genAI.getGenerativeModel({
+      model: "gemini-2.0-flash",
+      systemInstruction: systemMessage,
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens: type === 'email_customization' ? 2000 : 500,
+        ...(type === 'email_customization' ? { responseMimeType: "application/json" } : {}),
+      },
     });
-    
-    const aiResponse = completion.choices[0]?.message?.content || 'No response generated';
+
+    const result = await model.generateContent(prompt);
+    const aiResponse = result.response.text() || 'No response generated';
     
     // Handle email customization response
     if (type === 'email_customization') {

--- a/src/app/api/document-parser/route.ts
+++ b/src/app/api/document-parser/route.ts
@@ -1,6 +1,6 @@
 // app/api/document-parser/route.ts
 import { NextRequest, NextResponse } from 'next/server'
-import { OpenAI } from 'openai'
+import { GoogleGenerativeAI } from '@google/generative-ai'
 import { parse } from 'csv-parse/sync'
 import ExcelJS from 'exceljs'
 import { getOrganizationByAccessCode, uploadContactsWithDuplicateCheck, formatPhoneNumber } from '@/lib/supabase'
@@ -209,27 +209,24 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    console.log('Preparing to call OpenAI for parsing')
+    console.log('Preparing to call Gemini for parsing')
 
-    const client = new OpenAI({
-      apiKey: process.env['OPENAI_API_KEY'],
-    });
-
-    // Call OpenAI to parse the text
-    console.log('Calling OpenAI API')
-    const completion = await client.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
-        { role: 'user', content: textContent }
-      ],
-      response_format: { type: "json_object" }
+    const genAI = new GoogleGenerativeAI(process.env['GEMINI_API_KEY'] || '')
+    const model = genAI.getGenerativeModel({
+      model: "gemini-2.0-flash",
+      systemInstruction: SYSTEM_PROMPT,
+      generationConfig: {
+        responseMimeType: "application/json",
+      },
     })
 
-    console.log('OpenAI API response received')
+    console.log('Calling Gemini API')
+    const result = await model.generateContent(textContent)
 
-    const raw = completion.choices[0].message.content
-    console.log(`OpenAI response preview: ${raw?.substring(0, 200)}...`)
+    console.log('Gemini API response received')
+
+    const raw = result.response.text()
+    console.log(`Gemini response preview: ${raw?.substring(0, 200)}...`)
 
     let parsedResponse: { contacts?: Contact[] } | Contact[] | Record<string, unknown>
     let contacts: Contact[] = []
@@ -245,8 +242,8 @@ export async function POST(request: NextRequest) {
         contacts = []
       }
     } catch (parseError) {
-      console.error('Failed to parse OpenAI response as JSON:', parseError)
-      console.error('Raw OpenAI response:', raw)
+      console.error('Failed to parse Gemini response as JSON:', parseError)
+      console.error('Raw Gemini response:', raw)
 
       // Try to extract any potential JSON from the response
       if (raw) {

--- a/src/app/api/email-beautify/route.ts
+++ b/src/app/api/email-beautify/route.ts
@@ -2,12 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 // Configure function timeout for Vercel
 export const maxDuration = 30; // 30 seconds
-import OpenAI from 'openai';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
 
 // Email template styles
 const emailTemplates = {
@@ -411,22 +408,18 @@ RESPOND WITH ONLY THIS JSON FORMAT (no other text):
   "signature": "suggested organization signature"
 }`;
 
-    // Call OpenAI API with increased token limit for larger emails
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [
-        {
-          role: "system",
-          content: "You are an expert email designer and copywriter. You help create beautiful, professional HTML email layouts. IMPORTANT: Always respond with ONLY valid JSON in the exact format specified. Do not include any explanations, markdown formatting, or additional text outside the JSON object."
-        },
-        { role: "user", content: enhancementPrompt }
-      ],
-      temperature: 0.7,
-      max_tokens: 3000, // Increased from 1500 to handle larger emails
-      response_format: { type: "json_object" }, // Enforce JSON mode for reliable parsing
+    const model = genAI.getGenerativeModel({
+      model: "gemini-2.0-flash",
+      systemInstruction: "You are an expert email designer and copywriter. You help create beautiful, professional HTML email layouts. IMPORTANT: Always respond with ONLY valid JSON in the exact format specified. Do not include any explanations, markdown formatting, or additional text outside the JSON object.",
+      generationConfig: {
+        temperature: 0.7,
+        maxOutputTokens: 3000,
+        responseMimeType: "application/json",
+      },
     });
 
-    const aiResponse = completion.choices[0]?.message?.content || '{}';
+    const result = await model.generateContent(enhancementPrompt);
+    const aiResponse = result.response.text() || '{}';
 
     let aiEnhancements;
     try {

--- a/src/app/api/email-conversation/route.ts
+++ b/src/app/api/email-conversation/route.ts
@@ -1,10 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
-import OpenAI from 'openai';
+import { GoogleGenerativeAI, Content } from '@google/generative-ai';
 
-// Initialize OpenAI client
-const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
-});
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+
+const SYSTEM_INSTRUCTION = `You are an expert HTML email designer and frontend developer.
+Your goal is to help users customize their email designs through conversation.
+
+CONTEXT:
+You have access to the current HTML of the email.
+You will receive a conversation history to understand the context of changes (e.g., "Make it blue" after discussing the header means "Make the header blue").
+
+INSTRUCTIONS:
+1. Parse the user's request in the context of the conversation history.
+2. If the user asks for a visual change (color, layout, font, spacing, adding/removing elements), YOU MUST update the HTML code.
+3. If the user asks for content changes, update the text within the HTML.
+4. Ensure all HTML is valid, inline-styled (for email compatibility), and responsive.
+5. If the request is vague, ask for clarification but also offer a best-guess change if possible.
+6. Provide 3 short, relevant follow-up suggestions for the user.
+
+OUTPUT FORMAT:
+You MUST respond with a valid JSON object. Do not include any markdown formatting or explanation outside the JSON.
+{
+  "message": "A conversational response explaining what you did or asking for clarification.",
+  "updatedHtml": "The complete, modified HTML string. Return null if no changes were made to the HTML.",
+  "suggestions": ["Suggestion 1", "Suggestion 2", "Suggestion 3"],
+  "changesSummary": "A brief technical summary of changes (e.g., 'Changed header background to #0000FF') or null."
+}`;
 
 // Helper to strip markdown code blocks from JSON response
 function cleanJsonResponse(response: string): string {
@@ -35,57 +56,31 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // Construct the messages array for the AI
-        const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
-            {
-                role: "system",
-                content: `You are an expert HTML email designer and frontend developer. 
-Your goal is to help users customize their email designs through conversation.
-
-CONTEXT:
-You have access to the current HTML of the email.
-You will receive a conversation history to understand the context of changes (e.g., "Make it blue" after discussing the header means "Make the header blue").
-
-INSTRUCTIONS:
-1. Parse the user's request in the context of the conversation history.
-2. If the user asks for a visual change (color, layout, font, spacing, adding/removing elements), YOU MUST update the HTML code.
-3. If the user asks for content changes, update the text within the HTML.
-4. Ensure all HTML is valid, inline-styled (for email compatibility), and responsive.
-5. If the request is vague, ask for clarification but also offer a best-guess change if possible.
-6. Provide 3 short, relevant follow-up suggestions for the user.
-
-OUTPUT FORMAT:
-You MUST respond with a valid JSON object. Do not include any markdown formatting or explanation outside the JSON.
-{
-  "message": "A conversational response explaining what you did or asking for clarification.",
-  "updatedHtml": "The complete, modified HTML string. Return null if no changes were made to the HTML.",
-  "suggestions": ["Suggestion 1", "Suggestion 2", "Suggestion 3"],
-  "changesSummary": "A brief technical summary of changes (e.g., 'Changed header background to #0000FF') or null."
-}`
-            }
-        ];
-
-        // Add conversation history
+        // Build Gemini chat history from conversation
+        const history: Content[] = [];
         if (conversationHistory && Array.isArray(conversationHistory)) {
-            // Filter out any messages that might be invalid
             const validHistory = conversationHistory.filter(msg => msg.role === 'user' || msg.role === 'assistant');
 
-            // Exclude the last message if it matches the current 'message' payload to avoid duplication
-            // (Since the frontend optimistically adds it to history)
             const lastMsg = validHistory[validHistory.length - 1];
             const historyToUse = (lastMsg && lastMsg.role === 'user' && lastMsg.content === message)
                 ? validHistory.slice(0, -1)
                 : validHistory;
 
-            historyToUse.forEach(msg => {
-                messages.push({
-                    role: msg.role as 'user' | 'assistant',
-                    content: msg.content
+            // Gemini requires history to start with a 'user' role
+            let startIdx = 0;
+            while (startIdx < historyToUse.length && historyToUse[startIdx].role !== 'user') {
+                startIdx++;
+            }
+
+            for (let i = startIdx; i < historyToUse.length; i++) {
+                const msg = historyToUse[i];
+                history.push({
+                    role: msg.role === 'assistant' ? 'model' : 'user',
+                    parts: [{ text: msg.content }],
                 });
-            });
+            }
         }
 
-        // Add the current context and latest user message
         const userPrompt = `
 CURRENT EMAIL HTML:
 ${currentHtml || 'No HTML provided yet.'}
@@ -99,21 +94,19 @@ USER REQUEST:
 ${message}
 `;
 
-        messages.push({
-            role: "user",
-            content: userPrompt
+        const model = genAI.getGenerativeModel({
+            model: "gemini-2.0-flash",
+            systemInstruction: SYSTEM_INSTRUCTION,
+            generationConfig: {
+                temperature: 0.7,
+                maxOutputTokens: 4000,
+                responseMimeType: "application/json",
+            },
         });
 
-        // Call OpenAI API
-        const completion = await openai.chat.completions.create({
-            model: "gpt-4o-mini", // Using mini for speed/cost, can upgrade to gpt-4o if complex logic fails
-            messages: messages,
-            temperature: 0.7,
-            response_format: { type: "json_object" }, // Enforce JSON mode
-            max_tokens: 4000, // Allow enough tokens for full HTML return
-        });
-
-        const aiResponseContent = completion.choices[0]?.message?.content;
+        const chat = model.startChat({ history });
+        const result = await chat.sendMessage(userPrompt);
+        const aiResponseContent = result.response.text();
 
         if (!aiResponseContent) {
             throw new Error("No response from AI");

--- a/src/app/check-in/[code]/page.tsx
+++ b/src/app/check-in/[code]/page.tsx
@@ -5,11 +5,11 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Loader2, CheckCircle2, AlertCircle, ArrowRight, User, Mail, Phone } from 'lucide-react';
+import { Loader2, CheckCircle2, AlertCircle, ArrowRight, User, Mail, Phone, ShieldCheck } from 'lucide-react';
 import { submitAttendance } from '@/app/actions/attendance';
 import { useParams } from 'next/navigation';
+import AnimatedBackground from '@/components/AnimatedBackground';
 
-// --- Form Schemas ---
 const phoneSchema = z.object({
     phoneNumber: z.string().min(10, 'Phone number must be at least 10 digits'),
 });
@@ -32,15 +32,17 @@ export default function CheckInPage() {
     const [loading, setLoading] = useState(false);
     const [memberName, setMemberName] = useState<string | null>(null);
 
-    // Phone Form
-    const { register: registerPhone, handleSubmit: handleSubmitPhone, formState: { errors: phoneErrors } } = useForm<PhoneFormValues>({
-        resolver: zodResolver(phoneSchema),
-    });
+    const {
+        register: registerPhone,
+        handleSubmit: handleSubmitPhone,
+        formState: { errors: phoneErrors },
+    } = useForm<PhoneFormValues>({ resolver: zodResolver(phoneSchema) });
 
-    // Details Form
-    const { register: registerDetails, handleSubmit: handleSubmitDetails, formState: { errors: detailsErrors } } = useForm<DetailsFormValues>({
-        resolver: zodResolver(detailsSchema),
-    });
+    const {
+        register: registerDetails,
+        handleSubmit: handleSubmitDetails,
+        formState: { errors: detailsErrors },
+    } = useForm<DetailsFormValues>({ resolver: zodResolver(detailsSchema) });
 
     const onSubmitPhone = async (data: PhoneFormValues) => {
         setLoading(true);
@@ -88,9 +90,7 @@ export default function CheckInPage() {
                 setMemberName(result.memberName || `${data.firstName} ${data.lastName}`);
                 setStep(3);
             } else {
-                if ('error' in result) {
-                    setErrorMessage(result.error);
-                }
+                if ('error' in result) setErrorMessage(result.error);
             }
         } catch {
             setErrorMessage('An unexpected error occurred. Please try again.');
@@ -100,166 +100,200 @@ export default function CheckInPage() {
     };
 
     return (
-        <div className="min-h-screen w-full bg-gradient-to-br from-gray-900 to-black text-white flex flex-col items-center justify-center p-4 overflow-hidden relative">
-            {/* Background Decorative Elements */}
-            <div className="absolute top-[-10%] left-[-10%] w-[50%] h-[50%] bg-purple-600/20 rounded-full blur-[120px] pointer-events-none" />
-            <div className="absolute bottom-[-10%] right-[-10%] w-[50%] h-[50%] bg-blue-600/20 rounded-full blur-[120px] pointer-events-none" />
+        <AnimatedBackground variant="hero">
+            <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center px-6 py-10">
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6 }}
+                    className="w-full"
+                >
+                    <div className="rounded-2xl border border-border/80 bg-card/90 p-8 shadow-elevated backdrop-blur-xl">
+                        <div className="flex justify-center">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                                <ShieldCheck className="h-6 w-6" />
+                            </div>
+                        </div>
+                        <div className="mt-5 text-center">
+                            <h1 className="text-2xl font-semibold tracking-tight">Event check-in</h1>
+                            <p className="mt-2 text-sm text-muted-foreground">
+                                {step === 1 && 'Enter your phone number to get started.'}
+                                {step === 2 && "We don't have you yet — quick details below."}
+                                {step === 3 && "You're all set. Enjoy the event!"}
+                            </p>
+                        </div>
 
-            <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6 }}
-                className="w-full max-w-md relative z-10"
-            >
-                <div className="backdrop-blur-xl bg-white/5 border border-white/10 rounded-3xl p-8 shadow-2xl">
-                    <div className="mb-8 text-center">
-                        <h1 className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-400 mb-2">
-                            Event Check-in
-                        </h1>
-                        <p className="text-gray-400 text-sm">
-                            {step === 1 && "Enter your phone number to get started"}
-                            {step === 2 && "We found you're new! Please complete your profile"}
-                            {step === 3 && "You're all set! Enjoy the event"}
-                        </p>
-                    </div>
+                        <div className="mt-6">
+                            <AnimatePresence mode="wait">
+                                {step === 1 && (
+                                    <motion.form
+                                        key="step1"
+                                        initial={{ opacity: 0, x: -16 }}
+                                        animate={{ opacity: 1, x: 0 }}
+                                        exit={{ opacity: 0, x: 16 }}
+                                        onSubmit={handleSubmitPhone(onSubmitPhone)}
+                                        className="space-y-5"
+                                    >
+                                        <div className="space-y-1.5">
+                                            <label htmlFor="phoneNumber" className="text-sm font-medium">
+                                                Phone number
+                                            </label>
+                                            <div className="relative">
+                                                <Phone className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                <input
+                                                    {...registerPhone('phoneNumber')}
+                                                    type="tel"
+                                                    placeholder="(555) 123-4567"
+                                                    className="h-11 w-full rounded-lg border border-input bg-background py-2 pl-10 pr-4 text-sm shadow-xs outline-none transition-all hover:border-input/80 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30"
+                                                />
+                                            </div>
+                                            {phoneErrors.phoneNumber && (
+                                                <p className="flex items-center gap-1 text-xs text-destructive">
+                                                    <AlertCircle className="h-3 w-3" />
+                                                    {phoneErrors.phoneNumber.message}
+                                                </p>
+                                            )}
+                                        </div>
 
-                    <AnimatePresence mode="wait">
-                        {step === 1 && (
-                            <motion.form
-                                key="step1"
-                                initial={{ opacity: 0, x: -20 }}
-                                animate={{ opacity: 1, x: 0 }}
-                                exit={{ opacity: 0, x: 20 }}
-                                onSubmit={handleSubmitPhone(onSubmitPhone)}
-                                className="space-y-6"
-                            >
-                                <div className="space-y-2">
-                                    <label htmlFor="phoneNumber" className="text-sm font-medium text-gray-300 ml-1">Phone Number</label>
-                                    <div className="relative">
-                                        <Phone className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-500 h-5 w-5" />
-                                        <input
-                                            {...registerPhone('phoneNumber')}
-                                            type="tel"
-                                            placeholder="(555) 123-4567"
-                                            className="w-full bg-black/20 border border-white/10 rounded-xl py-3 pl-12 pr-4 text-white placeholder:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 transition-all"
-                                        />
-                                    </div>
-                                    {phoneErrors.phoneNumber && (
-                                        <p className="text-red-400 text-xs ml-1 flex items-center gap-1">
-                                            <AlertCircle className="w-3 h-3" /> {phoneErrors.phoneNumber.message}
+                                        <button
+                                            type="submit"
+                                            disabled={loading}
+                                            className="flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-primary text-sm font-medium text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-[0.98] disabled:opacity-60"
+                                        >
+                                            {loading ? (
+                                                <Loader2 className="h-4 w-4 animate-spin" />
+                                            ) : (
+                                                <>
+                                                    Continue <ArrowRight className="h-4 w-4" />
+                                                </>
+                                            )}
+                                        </button>
+                                    </motion.form>
+                                )}
+
+                                {step === 2 && (
+                                    <motion.form
+                                        key="step2"
+                                        initial={{ opacity: 0, x: -16 }}
+                                        animate={{ opacity: 1, x: 0 }}
+                                        exit={{ opacity: 0, x: 16 }}
+                                        onSubmit={handleSubmitDetails(onSubmitDetails)}
+                                        className="space-y-4"
+                                    >
+                                        <div className="grid grid-cols-2 gap-3">
+                                            <div className="space-y-1.5">
+                                                <label className="text-sm font-medium">First name</label>
+                                                <div className="relative">
+                                                    <User className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                    <input
+                                                        {...registerDetails('firstName')}
+                                                        placeholder="Jane"
+                                                        className="h-11 w-full rounded-lg border border-input bg-background py-2 pl-10 pr-3 text-sm shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30"
+                                                    />
+                                                </div>
+                                                {detailsErrors.firstName && (
+                                                    <p className="text-xs text-destructive">
+                                                        {detailsErrors.firstName.message}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            <div className="space-y-1.5">
+                                                <label className="text-sm font-medium">Last name</label>
+                                                <div className="relative">
+                                                    <User className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                    <input
+                                                        {...registerDetails('lastName')}
+                                                        placeholder="Doe"
+                                                        className="h-11 w-full rounded-lg border border-input bg-background py-2 pl-10 pr-3 text-sm shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30"
+                                                    />
+                                                </div>
+                                                {detailsErrors.lastName && (
+                                                    <p className="text-xs text-destructive">
+                                                        {detailsErrors.lastName.message}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div className="space-y-1.5">
+                                            <label className="text-sm font-medium">Email</label>
+                                            <div className="relative">
+                                                <Mail className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                                <input
+                                                    {...registerDetails('email')}
+                                                    type="email"
+                                                    placeholder="jane@example.com"
+                                                    className="h-11 w-full rounded-lg border border-input bg-background py-2 pl-10 pr-3 text-sm shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30"
+                                                />
+                                            </div>
+                                            {detailsErrors.email && (
+                                                <p className="text-xs text-destructive">
+                                                    {detailsErrors.email.message}
+                                                </p>
+                                            )}
+                                        </div>
+
+                                        <button
+                                            type="submit"
+                                            disabled={loading}
+                                            className="flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-primary text-sm font-medium text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-[0.98] disabled:opacity-60"
+                                        >
+                                            {loading ? (
+                                                <Loader2 className="h-4 w-4 animate-spin" />
+                                            ) : (
+                                                'Complete check-in'
+                                            )}
+                                        </button>
+                                    </motion.form>
+                                )}
+
+                                {step === 3 && (
+                                    <motion.div
+                                        key="step3"
+                                        initial={{ opacity: 0, scale: 0.95 }}
+                                        animate={{ opacity: 1, scale: 1 }}
+                                        className="flex flex-col items-center text-center"
+                                    >
+                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
+                                            <CheckCircle2 className="h-8 w-8" />
+                                        </div>
+                                        <h2 className="mt-4 text-xl font-semibold tracking-tight">
+                                            Checked in!
+                                        </h2>
+                                        <p className="mt-1 text-sm text-muted-foreground">
+                                            Welcome,{' '}
+                                            <span className="font-medium text-primary">{memberName}</span>.
                                         </p>
-                                    )}
-                                </div>
-
-                                <button
-                                    type="submit"
-                                    disabled={loading}
-                                    className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white font-semibold py-3.5 rounded-xl shadow-lg shadow-blue-900/20 transform transition-all hover:scale-[1.02] active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                                >
-                                    {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <>Continue <ArrowRight className="w-4 h-4" /></>}
-                                </button>
-                            </motion.form>
-                        )}
-
-                        {step === 2 && (
-                            <motion.form
-                                key="step2"
-                                initial={{ opacity: 0, x: -20 }}
-                                animate={{ opacity: 1, x: 0 }}
-                                exit={{ opacity: 0, x: 20 }}
-                                onSubmit={handleSubmitDetails(onSubmitDetails)}
-                                className="space-y-5"
-                            >
-                                <div className="grid grid-cols-2 gap-4">
-                                    <div className="space-y-2">
-                                        <label className="text-sm font-medium text-gray-300 ml-1">First Name</label>
-                                        <div className="relative">
-                                            <User className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-500 h-4 w-4" />
-                                            <input
-                                                {...registerDetails('firstName')}
-                                                placeholder="John"
-                                                className="w-full bg-black/20 border border-white/10 rounded-xl py-3 pl-10 pr-4 text-white placeholder:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
-                                            />
+                                        <div className="mt-5 w-full rounded-lg border border-border/80 bg-accent/40 p-3 text-center">
+                                            <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                                                Event code
+                                            </p>
+                                            <p className="mt-0.5 font-mono text-sm tracking-widest text-foreground">
+                                                {eventCode}
+                                            </p>
                                         </div>
-                                        {detailsErrors.firstName && <p className="text-red-400 text-xs ml-1">{detailsErrors.firstName.message}</p>}
-                                    </div>
-                                    <div className="space-y-2">
-                                        <label className="text-sm font-medium text-gray-300 ml-1">Last Name</label>
-                                        <div className="relative">
-                                            <User className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-500 h-4 w-4" />
-                                            <input
-                                                {...registerDetails('lastName')}
-                                                placeholder="Doe"
-                                                className="w-full bg-black/20 border border-white/10 rounded-xl py-3 pl-10 pr-4 text-white placeholder:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
-                                            />
-                                        </div>
-                                        {detailsErrors.lastName && <p className="text-red-400 text-xs ml-1">{detailsErrors.lastName.message}</p>}
-                                    </div>
-                                </div>
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+                        </div>
 
-                                <div className="space-y-2">
-                                    <label className="text-sm font-medium text-gray-300 ml-1">Email</label>
-                                    <div className="relative">
-                                        <Mail className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-500 h-4 w-4" />
-                                        <input
-                                            {...registerDetails('email')}
-                                            type="email"
-                                            placeholder="john@example.com"
-                                            className="w-full bg-black/20 border border-white/10 rounded-xl py-3 pl-10 pr-4 text-white placeholder:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
-                                        />
-                                    </div>
-                                    {detailsErrors.email && <p className="text-red-400 text-xs ml-1">{detailsErrors.email.message}</p>}
-                                </div>
-
-                                <button
-                                    type="submit"
-                                    disabled={loading}
-                                    className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white font-semibold py-3.5 rounded-xl shadow-lg shadow-blue-900/20 transform transition-all hover:scale-[1.02] active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2 mt-2"
-                                >
-                                    {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : "Complete Check-in"}
-                                </button>
-                            </motion.form>
-                        )}
-
-                        {step === 3 && (
+                        {errorMessage && (
                             <motion.div
-                                key="step3"
-                                initial={{ opacity: 0, scale: 0.9 }}
-                                animate={{ opacity: 1, scale: 1 }}
-                                className="flex flex-col items-center text-center py-6"
+                                initial={{ opacity: 0, y: 8 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                className="mt-5 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3"
                             >
-                                <div className="w-20 h-20 bg-green-500/20 rounded-full flex items-center justify-center mb-6">
-                                    <CheckCircle2 className="w-10 h-10 text-green-400" />
-                                </div>
-                                <h2 className="text-2xl font-bold text-white mb-2">Checked In!</h2>
-                                <p className="text-gray-400 mb-6">
-                                    Welcome to the event, <span className="text-blue-400 font-semibold">{memberName}</span>.
-                                </p>
-                                <div className="p-4 bg-white/5 rounded-xl border border-white/5 w-full">
-                                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Event Code</p>
-                                    <p className="text-lg font-mono text-white tracking-widest">{eventCode}</p>
-                                </div>
+                                <AlertCircle className="h-4 w-4 shrink-0 translate-y-0.5 text-destructive" />
+                                <p className="text-sm text-destructive">{errorMessage}</p>
                             </motion.div>
                         )}
-                    </AnimatePresence>
+                    </div>
 
-                    {errorMessage && (
-                        <motion.div
-                            initial={{ opacity: 0, y: 10 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            className="mt-6 p-3 bg-red-500/10 border border-red-500/20 rounded-lg flex items-start gap-3"
-                        >
-                            <AlertCircle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-                            <p className="text-sm text-red-300">{errorMessage}</p>
-                        </motion.div>
-                    )}
-
-                </div>
-
-                <div className="mt-8 text-center">
-                    <p className="text-xs text-gray-600">© 2026 Blitz Mass Communication</p>
-                </div>
-            </motion.div>
-        </div>
+                    <p className="mt-6 text-center text-xs text-muted-foreground">
+                        © {new Date().getFullYear()} Blitz · Mass Communication
+                    </p>
+                </motion.div>
+            </div>
+        </AnimatedBackground>
     );
 }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import React, { useState, useEffect } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -15,10 +14,20 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog"
 import { createEvent, getOrgEvents, getEventAttendees } from "@/app/actions/events"
-import { Plus, Calendar, QrCode, Users, ExternalLink, RefreshCw } from "lucide-react"
+import { Plus, Calendar, QrCode, Users, ExternalLink, RefreshCw, ArrowLeft, Loader2, Copy, Check } from "lucide-react"
 import { QRCode } from 'react-qrcode-logo';
 import { Event } from "@/lib/supabase"
 import AnimatedBackground from "@/components/AnimatedBackground"
+
+interface AttendeeRecord {
+    id: number;
+    created_at: string;
+    org_members: {
+        first_name: string;
+        last_name: string;
+        phone_number: string;
+    }
+}
 
 export default function EventsPage() {
     const router = useRouter()
@@ -28,24 +37,13 @@ export default function EventsPage() {
     const [selectedEvent, setSelectedEvent] = useState<Event | null>(null)
     const [showCreateDialog, setShowCreateDialog] = useState(false)
     const [showDetailDialog, setShowDetailDialog] = useState(false)
+    const [copied, setCopied] = useState(false)
 
-    // Create Form State
     const [newEventName, setNewEventName] = useState("")
     const [newEventDate, setNewEventDate] = useState("")
     const [newEventDesc, setNewEventDesc] = useState("")
     const [creating, setCreating] = useState(false)
 
-
-    // Attendees State
-    interface AttendeeRecord {
-        id: number;
-        created_at: string;
-        org_members: {
-            first_name: string;
-            last_name: string;
-            phone_number: string;
-        }
-    }
     const [attendees, setAttendees] = useState<AttendeeRecord[]>([])
     const [loadingAttendees, setLoadingAttendees] = useState(false)
 
@@ -116,7 +114,6 @@ export default function EventsPage() {
             setNewEventName("");
             setNewEventDate("");
             setNewEventDesc("");
-            // Refresh events
             fetchEvents(orgInfo.id);
         }
     }
@@ -127,204 +124,318 @@ export default function EventsPage() {
         loadAttendees(event.id);
     }
 
-    // Helper to get Check-in URL
     const getCheckInUrl = (code: string) => {
-        // Allow overriding the base URL via environment variable (useful for ngrok/tunneling)
-        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (typeof window !== 'undefined' ? window.location.origin : '');
+        const baseUrl =
+            process.env.NEXT_PUBLIC_BASE_URL ||
+            (typeof window !== 'undefined' ? window.location.origin : '');
         return `${baseUrl}/check-in/${code}`;
+    }
+
+    const handleCopy = (url: string) => {
+        navigator.clipboard.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    }
+
+    const formatEventDate = (date: string) => {
+        const d = new Date(date);
+        return {
+            date: d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+            time: d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+            relative: getRelative(d),
+        };
+    }
+
+    const getRelative = (d: Date) => {
+        const diff = d.getTime() - Date.now();
+        const days = Math.round(diff / (1000 * 60 * 60 * 24));
+        if (days === 0) return 'Today';
+        if (days === 1) return 'Tomorrow';
+        if (days === -1) return 'Yesterday';
+        if (days > 0 && days < 7) return `In ${days} days`;
+        if (days < 0 && days > -7) return `${-days} days ago`;
+        return null;
     }
 
     return (
         <AnimatedBackground>
-            <div className="min-h-screen p-8">
-                <div className="max-w-6xl mx-auto space-y-8 relative z-10">
-                    <div className="flex justify-between items-center">
-                        <div>
-                            <h1 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-400 bg-clip-text text-transparent">
-                                Events
-                            </h1>
-                            <p className="text-gray-400 mt-2">Manage your organization&apos;s events and attendance.</p>
-                        </div>
-                        <Button onClick={() => setShowCreateDialog(true)} className="bg-white text-black hover:bg-gray-200">
-                            <Plus className="mr-2 h-4 w-4" /> Create Event
+            <div className="mx-auto w-full max-w-6xl px-6 py-8 sm:py-12">
+                {/* Header */}
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => router.push('/mass-text')}
+                            className="-ml-2 mb-2 text-muted-foreground hover:text-foreground"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                            Dashboard
                         </Button>
+                        <h1 className="text-3xl font-semibold tracking-tight">Events</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            Run events with QR check-in and live attendance.
+                        </p>
                     </div>
+                    <Button onClick={() => setShowCreateDialog(true)} size="lg">
+                        <Plus className="h-4 w-4" />
+                        Create event
+                    </Button>
+                </div>
 
-                    {/* Event List */}
-                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                        {loading ? (
-                            <p className="text-gray-500">Loading events...</p>
-                        ) : events.length === 0 ? (
-                            <Card className="col-span-full border-gray-800 bg-gray-900/50 backdrop-blur-sm">
-                                <CardContent className="flex flex-col items-center justify-center py-12 text-gray-400">
-                                    <Calendar className="h-12 w-12 mb-4 opacity-50" />
-                                    <p>No events found. Create your first event!</p>
-                                </CardContent>
-                            </Card>
-                        ) : (
-                            events.map(event => (
-                                <Card key={event.id} className="border-gray-800 bg-gray-900/40 hover:bg-gray-900/60 backdrop-blur-sm transition-all duration-300 cursor-pointer group hover:shadow-lg hover:shadow-gray-900/20" onClick={() => openEventDetails(event)}>
-                                    <CardHeader>
-                                        <div className="flex justify-between items-start">
-                                            <CardTitle className="text-xl text-white group-hover:text-blue-400 transition-colors">{event.name}</CardTitle>
-                                            <Calendar className="h-4 w-4 text-gray-500" />
-                                        </div>
-                                        <CardDescription>
-                                            {new Date(event.event_date).toLocaleDateString()} at {new Date(event.event_date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                                        </CardDescription>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <p className="text-sm text-gray-400 truncate">{event.description || "No description"}</p>
-                                    </CardContent>
-                                    <CardFooter>
-                                        <Button variant="outline" className="w-full border-gray-700 hover:bg-gray-800 bg-transparent text-gray-300">
-                                            View Details
-                                        </Button>
-                                    </CardFooter>
-                                </Card>
-                            ))
-                        )}
-                    </div>
-
-                    {/* Create Event Dialog */}
-                    <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-                        <DialogContent className="bg-gray-900 border-gray-800 text-white sm:max-w-[425px]">
-                            <DialogHeader>
-                                <DialogTitle>Create New Event</DialogTitle>
-                                <DialogDescription>Add a new event for your organization.</DialogDescription>
-                            </DialogHeader>
-                            <div className="grid gap-4 py-4">
-                                <div className="grid gap-2">
-                                    <Label htmlFor="name">Event Name</Label>
-                                    <Input
-                                        id="name"
-                                        value={newEventName}
-                                        onChange={e => setNewEventName(e.target.value)}
-                                        className="bg-gray-800 border-gray-700 text-white placeholder-gray-500"
-                                        placeholder="e.g. Weekly Meeting"
-                                    />
+                {/* Events grid */}
+                <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {loading ? (
+                        <div className="col-span-full flex items-center justify-center py-12">
+                            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                        </div>
+                    ) : events.length === 0 ? (
+                        <div className="col-span-full">
+                            <div className="rounded-2xl border border-dashed border-border bg-card/50 p-12 text-center">
+                                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                                    <Calendar className="h-5 w-5" />
                                 </div>
-                                <div className="grid gap-2">
-                                    <Label htmlFor="date">Date & Time</Label>
-                                    <Input
-                                        id="date"
-                                        type="datetime-local"
-                                        value={newEventDate}
-                                        onChange={e => setNewEventDate(e.target.value)}
-                                        className="bg-gray-800 border-gray-700 text-white"
-                                    />
-                                </div>
-                                <div className="grid gap-2">
-                                    <Label htmlFor="desc">Description</Label>
-                                    <Input
-                                        id="desc"
-                                        value={newEventDesc}
-                                        onChange={e => setNewEventDesc(e.target.value)}
-                                        className="bg-gray-800 border-gray-700 text-white placeholder-gray-500"
-                                        placeholder="Optional description"
-                                    />
-                                </div>
-                            </div>
-                            <DialogFooter>
-                                <Button variant="ghost" onClick={() => setShowCreateDialog(false)} className="hover:bg-gray-800 text-gray-300">Cancel</Button>
-                                <Button onClick={handleCreateEvent} disabled={creating} className="bg-white text-black hover:bg-gray-200">
-                                    {creating ? 'Creating...' : 'Create Event'}
+                                <h3 className="mt-4 text-base font-semibold">No events yet</h3>
+                                <p className="mt-1 text-sm text-muted-foreground">
+                                    Create your first event to start tracking attendance.
+                                </p>
+                                <Button className="mt-6" onClick={() => setShowCreateDialog(true)}>
+                                    <Plus className="h-4 w-4" />
+                                    Create event
                                 </Button>
-                            </DialogFooter>
-                        </DialogContent>
-                    </Dialog>
+                            </div>
+                        </div>
+                    ) : (
+                        events.map((event) => {
+                            const f = formatEventDate(event.event_date);
+                            return (
+                                <button
+                                    key={event.id}
+                                    onClick={() => openEventDetails(event)}
+                                    className="group flex flex-col rounded-2xl border border-border/80 bg-card p-5 text-left shadow-soft transition-all hover:border-primary/40 hover:shadow-elevated"
+                                >
+                                    <div className="flex items-start justify-between">
+                                        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent text-primary">
+                                            <Calendar className="h-5 w-5" />
+                                        </div>
+                                        {f.relative && (
+                                            <span className="rounded-full bg-accent px-2.5 py-0.5 text-xs font-medium text-primary">
+                                                {f.relative}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <h3 className="mt-4 text-lg font-semibold tracking-tight group-hover:text-primary transition-colors">
+                                        {event.name}
+                                    </h3>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        {f.date} · {f.time}
+                                    </p>
+                                    <p className="mt-3 line-clamp-2 text-sm text-foreground/70">
+                                        {event.description || 'No description'}
+                                    </p>
+                                    <div className="mt-4 flex items-center text-xs font-medium text-primary group-hover:translate-x-0.5 transition-transform">
+                                        View details
+                                        <span className="ml-1">→</span>
+                                    </div>
+                                </button>
+                            );
+                        })
+                    )}
+                </div>
 
-                    {/* Event Detail Dialog */}
-                    <Dialog open={showDetailDialog} onOpenChange={setShowDetailDialog}>
-                        <DialogContent className="bg-gray-950/95 backdrop-blur-xl border-gray-800 text-white sm:max-w-[800px] max-h-[85vh] overflow-y-auto w-full">
-                            {selectedEvent && (
-                                <>
-                                    <DialogHeader>
-                                        <DialogTitle className="text-2xl font-bold bg-gradient-to-r from-white to-gray-400 bg-clip-text text-transparent">{selectedEvent.name}</DialogTitle>
-                                        <DialogDescription className="text-lg text-gray-400">
-                                            {new Date(selectedEvent.event_date).toLocaleDateString()} • {new Date(selectedEvent.event_date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                                        </DialogDescription>
-                                    </DialogHeader>
+                {/* Create Event Dialog */}
+                <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Create new event</DialogTitle>
+                            <DialogDescription>
+                                Set up an event and we&apos;ll generate a QR check-in link.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <div className="grid gap-4">
+                            <div className="space-y-1.5">
+                                <Label htmlFor="name">Event name</Label>
+                                <Input
+                                    id="name"
+                                    value={newEventName}
+                                    onChange={(e) => setNewEventName(e.target.value)}
+                                    placeholder="e.g. Spring Kickoff"
+                                />
+                            </div>
+                            <div className="space-y-1.5">
+                                <Label htmlFor="date">Date & time</Label>
+                                <Input
+                                    id="date"
+                                    type="datetime-local"
+                                    value={newEventDate}
+                                    onChange={(e) => setNewEventDate(e.target.value)}
+                                />
+                            </div>
+                            <div className="space-y-1.5">
+                                <Label htmlFor="desc">Description (optional)</Label>
+                                <Input
+                                    id="desc"
+                                    value={newEventDesc}
+                                    onChange={(e) => setNewEventDesc(e.target.value)}
+                                    placeholder="What's it about?"
+                                />
+                            </div>
+                        </div>
+                        <DialogFooter>
+                            <Button variant="ghost" onClick={() => setShowCreateDialog(false)}>
+                                Cancel
+                            </Button>
+                            <Button onClick={handleCreateEvent} disabled={creating}>
+                                {creating ? (
+                                    <>
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                        Creating…
+                                    </>
+                                ) : (
+                                    'Create event'
+                                )}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
 
-                                    <div className="grid md:grid-cols-2 gap-8 py-4">
-                                        {/* Link & QR Section */}
-                                        <div className="flex flex-col items-center space-y-4 p-6 bg-white/5 rounded-xl border border-gray-800/50 backdrop-blur-sm">
-                                            <h3 className="font-semibold text-gray-300 flex items-center gap-2">
-                                                <QrCode className="w-4 h-4" /> Check-in QR Code
-                                            </h3>
-                                            <div className="bg-white p-4 rounded-lg shadow-lg">
-                                                <QRCode
-                                                    value={getCheckInUrl(selectedEvent.code)}
-                                                    size={200}
-                                                    logoWidth={40}
-                                                    removeQrCodeBehindLogo
-                                                />
-                                            </div>
-                                            <div className="text-center w-full space-y-2">
-                                                <p className="text-xs text-gray-500">Scan to check in or use the link below</p>
-                                                <code className="block w-full bg-black/50 p-2 rounded text-xs break-all border border-gray-800 text-gray-400 font-mono">
+                {/* Event Detail Dialog */}
+                <Dialog open={showDetailDialog} onOpenChange={setShowDetailDialog}>
+                    <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[860px]">
+                        {selectedEvent && (
+                            <>
+                                <DialogHeader>
+                                    <DialogTitle className="text-2xl">{selectedEvent.name}</DialogTitle>
+                                    <DialogDescription>
+                                        {formatEventDate(selectedEvent.event_date).date} ·{' '}
+                                        {formatEventDate(selectedEvent.event_date).time}
+                                    </DialogDescription>
+                                </DialogHeader>
+
+                                <div className="grid gap-6 py-2 md:grid-cols-2">
+                                    {/* QR */}
+                                    <div className="flex flex-col items-center gap-4 rounded-2xl border border-border/80 bg-accent/30 p-6">
+                                        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                                            <QrCode className="h-4 w-4" /> Check-in QR
+                                        </div>
+                                        <div className="rounded-xl bg-white p-4 shadow-soft">
+                                            <QRCode
+                                                value={getCheckInUrl(selectedEvent.code)}
+                                                size={200}
+                                                logoWidth={40}
+                                                removeQrCodeBehindLogo
+                                            />
+                                        </div>
+                                        <div className="w-full space-y-2">
+                                            <p className="text-center text-xs text-muted-foreground">
+                                                Scan to check in or share the link below
+                                            </p>
+                                            <div className="flex items-center gap-2 rounded-lg border border-border bg-background p-2">
+                                                <code className="flex-1 truncate font-mono text-xs text-muted-foreground">
                                                     {getCheckInUrl(selectedEvent.code)}
                                                 </code>
-                                                <Button size="sm" variant="outline" className="w-full text-xs border-gray-700 hover:bg-gray-800 bg-transparent text-gray-300" onClick={() => window.open(getCheckInUrl(selectedEvent.code), '_blank')}>
-                                                    <ExternalLink className="w-3 h-3 mr-2" /> Open Check-in Page
+                                                <Button
+                                                    size="icon-sm"
+                                                    variant="ghost"
+                                                    onClick={() => handleCopy(getCheckInUrl(selectedEvent.code))}
+                                                >
+                                                    {copied ? (
+                                                        <Check className="h-3.5 w-3.5 text-emerald-600" />
+                                                    ) : (
+                                                        <Copy className="h-3.5 w-3.5" />
+                                                    )}
                                                 </Button>
                                             </div>
-                                        </div>
-
-                                        {/* Attendees Section */}
-                                        <div className="flex flex-col space-y-4">
-                                            <div className="flex items-center justify-between">
-                                                <h3 className="font-semibold text-gray-300 flex items-center gap-2">
-                                                    <Users className="w-4 h-4" /> Attendees ({attendees.length})
-                                                </h3>
-                                                <Button size="sm" variant="ghost" onClick={refreshAttendees} disabled={loadingAttendees} className="h-8 w-8 p-0 text-gray-400 hover:text-white">
-                                                    <RefreshCw className={`w-3 h-3 ${loadingAttendees ? 'animate-spin' : ''}`} />
-                                                </Button>
-                                            </div>
-
-                                            <div className="flex-1 bg-white/5 rounded-xl border border-gray-800/50 overflow-hidden flex flex-col h-[350px] backdrop-blur-sm">
-                                                {loadingAttendees ? (
-                                                    <div className="flex-1 flex items-center justify-center text-gray-500">Loading attendees...</div>
-                                                ) : attendees.length === 0 ? (
-                                                    <div className="flex-1 flex flex-col items-center justify-center text-gray-500 text-sm p-8 text-center space-y-2">
-                                                        <Users className="h-8 w-8 opacity-20" />
-                                                        <p>No attendees yet.</p>
-                                                        <p className="text-xs opacity-50">Share the QR code to start tracking attendance.</p>
-                                                    </div>
-                                                ) : (
-                                                    <div className="overflow-y-auto">
-                                                        <table className="w-full text-sm text-left">
-                                                            <thead className="text-xs text-gray-400 uppercase bg-black/20 sticky top-0 backdrop-blur-sm">
-                                                                <tr>
-                                                                    <th className="px-4 py-3 font-medium">Name</th>
-                                                                    <th className="px-4 py-3 font-medium">Phone</th>
-                                                                    <th className="px-4 py-3 font-medium text-right">Time</th>
-                                                                </tr>
-                                                            </thead>
-                                                            <tbody className="divide-y divide-gray-800/50">
-                                                                {attendees.map((att) => (
-                                                                    <tr key={att.id} className="hover:bg-white/5 transition-colors">
-                                                                        <td className="px-4 py-3 font-medium text-gray-200">
-                                                                            {att.org_members.first_name} {att.org_members.last_name}
-                                                                        </td>
-                                                                        <td className="px-4 py-3 text-gray-400 font-mono text-xs">{att.org_members.phone_number}</td>
-                                                                        <td className="px-4 py-3 text-gray-500 text-xs text-right">
-                                                                            {new Date(att.created_at).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
-                                                                        </td>
-                                                                    </tr>
-                                                                ))}
-                                                            </tbody>
-                                                        </table>
-                                                    </div>
-                                                )}
-                                            </div>
+                                            <Button
+                                                size="sm"
+                                                variant="outline"
+                                                className="w-full"
+                                                onClick={() =>
+                                                    window.open(getCheckInUrl(selectedEvent.code), '_blank')
+                                                }
+                                            >
+                                                <ExternalLink className="h-3.5 w-3.5" />
+                                                Open check-in page
+                                            </Button>
                                         </div>
                                     </div>
-                                </>
-                            )}
-                        </DialogContent>
-                    </Dialog>
-                </div>
+
+                                    {/* Attendees */}
+                                    <div className="flex flex-col gap-3">
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-1.5 text-sm font-medium">
+                                                <Users className="h-4 w-4" />
+                                                Attendees ({attendees.length})
+                                            </div>
+                                            <Button
+                                                size="icon-sm"
+                                                variant="ghost"
+                                                onClick={refreshAttendees}
+                                                disabled={loadingAttendees}
+                                            >
+                                                <RefreshCw
+                                                    className={`h-3.5 w-3.5 ${loadingAttendees ? 'animate-spin' : ''}`}
+                                                />
+                                            </Button>
+                                        </div>
+
+                                        <div className="flex h-[360px] flex-col overflow-hidden rounded-2xl border border-border/80 bg-card">
+                                            {loadingAttendees ? (
+                                                <div className="flex flex-1 items-center justify-center text-muted-foreground">
+                                                    <Loader2 className="h-5 w-5 animate-spin" />
+                                                </div>
+                                            ) : attendees.length === 0 ? (
+                                                <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+                                                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent text-primary">
+                                                        <Users className="h-5 w-5" />
+                                                    </div>
+                                                    <p className="mt-3 text-sm font-medium">No attendees yet</p>
+                                                    <p className="mt-1 text-xs text-muted-foreground">
+                                                        Share the QR code to start tracking.
+                                                    </p>
+                                                </div>
+                                            ) : (
+                                                <div className="overflow-y-auto">
+                                                    <table className="w-full text-left text-sm">
+                                                        <thead className="sticky top-0 bg-card text-xs uppercase tracking-wider text-muted-foreground">
+                                                            <tr className="border-b border-border/80">
+                                                                <th className="px-4 py-3 font-medium">Name</th>
+                                                                <th className="px-4 py-3 font-medium">Phone</th>
+                                                                <th className="px-4 py-3 text-right font-medium">Time</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody className="divide-y divide-border/60">
+                                                            {attendees.map((att) => (
+                                                                <tr
+                                                                    key={att.id}
+                                                                    className="transition-colors hover:bg-accent/40"
+                                                                >
+                                                                    <td className="px-4 py-3 font-medium text-foreground">
+                                                                        {att.org_members.first_name}{' '}
+                                                                        {att.org_members.last_name}
+                                                                    </td>
+                                                                    <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                                                                        {att.org_members.phone_number}
+                                                                    </td>
+                                                                    <td className="px-4 py-3 text-right text-xs text-muted-foreground">
+                                                                        {new Date(att.created_at).toLocaleTimeString([], {
+                                                                            hour: 'numeric',
+                                                                            minute: '2-digit',
+                                                                        })}
+                                                                    </td>
+                                                                </tr>
+                                                            ))}
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            </>
+                        )}
+                    </DialogContent>
+                </Dialog>
             </div>
         </AnimatedBackground>
     )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,79 +37,105 @@
     --color-popover: var(--popover);
     --color-card-foreground: var(--card-foreground);
     --color-card: var(--card);
+    --color-surface: var(--surface);
+    --color-surface-elevated: var(--surface-elevated);
     --radius-sm: calc(var(--radius) - 4px);
     --radius-md: calc(var(--radius) - 2px);
     --radius-lg: var(--radius);
     --radius-xl: calc(var(--radius) + 4px);
+    --radius-2xl: calc(var(--radius) + 8px);
 }
 
 :root {
-    --radius: 0.625rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
+    --radius: 0.75rem;
+
+    /* Refined neutral base — warm-tinged off-white */
+    --background: oklch(0.99 0.002 270);
+    --foreground: oklch(0.18 0.01 270);
+
+    --surface: oklch(1 0 0);
+    --surface-elevated: oklch(0.985 0.003 270);
+
     --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
+    --card-foreground: oklch(0.18 0.01 270);
     --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+    --popover-foreground: oklch(0.18 0.01 270);
+
+    /* Primary: deep indigo — sophisticated, confident */
+    --primary: oklch(0.32 0.15 275);
+    --primary-foreground: oklch(0.99 0 0);
+
+    --secondary: oklch(0.965 0.005 270);
+    --secondary-foreground: oklch(0.22 0.015 270);
+    --muted: oklch(0.965 0.005 270);
+    --muted-foreground: oklch(0.5 0.015 270);
+    --accent: oklch(0.96 0.01 275);
+    --accent-foreground: oklch(0.32 0.15 275);
+
+    --destructive: oklch(0.55 0.22 27);
+
+    --border: oklch(0.92 0.005 270);
+    --input: oklch(0.92 0.005 270);
+    --ring: oklch(0.55 0.18 275);
+
+    --chart-1: oklch(0.55 0.18 275);
+    --chart-2: oklch(0.6 0.15 200);
+    --chart-3: oklch(0.7 0.14 160);
+    --chart-4: oklch(0.72 0.18 60);
+    --chart-5: oklch(0.62 0.2 340);
+
+    --sidebar: oklch(0.985 0.003 270);
+    --sidebar-foreground: oklch(0.18 0.01 270);
+    --sidebar-primary: oklch(0.32 0.15 275);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.96 0.01 275);
+    --sidebar-accent-foreground: oklch(0.32 0.15 275);
+    --sidebar-border: oklch(0.92 0.005 270);
+    --sidebar-ring: oklch(0.55 0.18 275);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+    --background: oklch(0.13 0.012 270);
+    --foreground: oklch(0.98 0 0);
+
+    --surface: oklch(0.17 0.012 270);
+    --surface-elevated: oklch(0.2 0.012 270);
+
+    --card: oklch(0.17 0.012 270);
+    --card-foreground: oklch(0.98 0 0);
+    --popover: oklch(0.17 0.012 270);
+    --popover-foreground: oklch(0.98 0 0);
+
+    --primary: oklch(0.7 0.18 275);
+    --primary-foreground: oklch(0.13 0.012 270);
+
+    --secondary: oklch(0.22 0.012 270);
+    --secondary-foreground: oklch(0.98 0 0);
+    --muted: oklch(0.22 0.012 270);
+    --muted-foreground: oklch(0.65 0.012 270);
+    --accent: oklch(0.25 0.025 275);
+    --accent-foreground: oklch(0.85 0.1 275);
+
+    --destructive: oklch(0.7 0.19 22);
+
+    --border: oklch(1 0 0 / 8%);
+    --input: oklch(1 0 0 / 12%);
+    --ring: oklch(0.7 0.18 275);
+
+    --chart-1: oklch(0.7 0.18 275);
+    --chart-2: oklch(0.7 0.15 200);
+    --chart-3: oklch(0.75 0.14 160);
+    --chart-4: oklch(0.78 0.18 60);
+    --chart-5: oklch(0.72 0.2 340);
+
+    --sidebar: oklch(0.17 0.012 270);
+    --sidebar-foreground: oklch(0.98 0 0);
+    --sidebar-primary: oklch(0.7 0.18 275);
+    --sidebar-primary-foreground: oklch(0.13 0.012 270);
+    --sidebar-accent: oklch(0.25 0.025 275);
+    --sidebar-accent-foreground: oklch(0.85 0.1 275);
+    --sidebar-border: oklch(1 0 0 / 8%);
+    --sidebar-ring: oklch(0.7 0.18 275);
 }
 
 @layer base {
@@ -117,82 +143,140 @@
         @apply border-border outline-ring/50;
     }
 
+    html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-rendering: optimizeLegibility;
+    }
+
     body {
         @apply bg-background text-foreground;
+        font-feature-settings: "ss01", "cv01", "cv11";
     }
+
+    /* Refined headings */
+    h1, h2, h3, h4 {
+        letter-spacing: -0.02em;
+    }
+}
+
+/* Subtle dotted grid background utility */
+.bg-grid {
+    background-image:
+        radial-gradient(circle at 1px 1px, oklch(0.7 0.01 270 / 0.18) 1px, transparent 0);
+    background-size: 24px 24px;
+}
+
+.bg-grid-fade {
+    mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 30%, transparent 80%);
+    -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 30%, transparent 80%);
+}
+
+/* Refined surface treatments */
+.surface-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.surface-glow {
+    background: radial-gradient(
+        ellipse 80% 50% at 50% -10%,
+        oklch(0.55 0.18 275 / 0.12),
+        transparent 60%
+    );
+}
+
+/* Brand wordmark gradient — single refined treatment */
+.brand-wordmark {
+    background: linear-gradient(
+        135deg,
+        oklch(0.25 0.18 275) 0%,
+        oklch(0.45 0.22 295) 50%,
+        oklch(0.32 0.18 260) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+}
+
+.dark .brand-wordmark {
+    background: linear-gradient(
+        135deg,
+        oklch(0.85 0.16 275) 0%,
+        oklch(0.78 0.2 295) 50%,
+        oklch(0.82 0.18 260) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+}
+
+/* Soft elevated shadow */
+.shadow-soft {
+    box-shadow:
+        0 1px 2px oklch(0.18 0.01 270 / 0.04),
+        0 4px 12px oklch(0.18 0.01 270 / 0.04);
+}
+
+.shadow-elevated {
+    box-shadow:
+        0 1px 2px oklch(0.18 0.01 270 / 0.05),
+        0 8px 24px oklch(0.18 0.01 270 / 0.08);
 }
 
 @keyframes gradient {
-    0% {
-        background-position: 0% 50%;
-    }
-
-    50% {
-        background-position: 100% 50%;
-    }
-
-    100% {
-        background-position: 0% 50%;
-    }
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
 }
 
 .animate-gradient {
-    animation: gradient 5s ease infinite;
+    animation: gradient 8s ease infinite;
     background-size: 200% 100%;
 }
 
 @keyframes line {
-    0% {
-        transform: translateX(-100%);
-    }
-
-    50% {
-        transform: translateX(0);
-    }
-
-    100% {
-        transform: translateX(100%);
-    }
+    0% { transform: translateX(-100%); }
+    50% { transform: translateX(0); }
+    100% { transform: translateX(100%); }
 }
 
 @keyframes breath {
-
-    0%,
-    100% {
-        transform: scale(1);
-    }
-
-    50% {
-        transform: scale(1.1);
-    }
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.1); }
 }
 
 @keyframes spin {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(360deg);
-    }
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 }
 
 @keyframes fadeOut {
-    from {
-        opacity: 1;
-    }
-    to {
-        opacity: 0;
-    }
+    from { opacity: 1; }
+    to { opacity: 0; }
 }
 
 @keyframes scaleOut {
-    from {
-        transform: scale(1);
-    }
-    to {
-        transform: scale(0.95);
-    }
+    from { transform: scale(1); }
+    to { transform: scale(0.95); }
+}
+
+@keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+}
+
+@keyframes float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-8px); }
+}
+
+@keyframes glow-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.7; }
 }
 
 .animate-fadeOut {
@@ -201,4 +285,37 @@
 
 .animate-scaleOut {
     animation: scaleOut 0.4s ease-out forwards;
+}
+
+.animate-float {
+    animation: float 6s ease-in-out infinite;
+}
+
+.animate-glow-pulse {
+    animation: glow-pulse 4s ease-in-out infinite;
+}
+
+/* Custom scrollbar — minimal, refined */
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: oklch(0.85 0.005 270);
+    border-radius: 8px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: oklch(0.75 0.005 270);
+    background-clip: padding-box;
+    border: 2px solid transparent;
+}
+.dark ::-webkit-scrollbar-thumb {
+    background: oklch(0.3 0.012 270);
+    background-clip: padding-box;
+    border: 2px solid transparent;
 }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,50 +1,95 @@
-// src/app/join/page.tsx
 'use client';
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import JoinOrgForm from '@/components/JoinOrgForm';
+import AnimatedBackground from '@/components/AnimatedBackground';
+import { Loader2, AlertCircle, Users } from 'lucide-react';
 
 function JoinPageContent() {
-  const params = useSearchParams();
-  const orgSlug = params.get('org');
-  const [org, setOrg] = useState<{ name: string } | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+    const params = useSearchParams();
+    const orgSlug = params.get('org');
+    const [org, setOrg] = useState<{ name: string } | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!orgSlug) {
-      setError('No organization specified.');
-      setLoading(false);
-      return;
+    useEffect(() => {
+        if (!orgSlug) {
+            setError('No organization specified.');
+            setLoading(false);
+            return;
+        }
+        fetch(`/api/org-info?slug=${encodeURIComponent(orgSlug)}`)
+            .then((res) => res.json())
+            .then((data) => {
+                if (data.error) setError(data.error);
+                else setOrg(data.org);
+            })
+            .catch(() => setError('Failed to load organization.'))
+            .finally(() => setLoading(false));
+    }, [orgSlug]);
+
+    if (loading) {
+        return (
+            <div className="flex min-h-screen items-center justify-center">
+                <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                    <Loader2 className="h-8 w-8 animate-spin" />
+                    <p className="text-sm">Loading organization…</p>
+                </div>
+            </div>
+        );
     }
-    fetch(`/api/org-info?slug=${encodeURIComponent(orgSlug)}`)
-      .then(res => res.json())
-      .then(data => {
-        if (data.error) setError(data.error);
-        else setOrg(data.org);
-      })
-      .catch(() => setError('Failed to load organization.'))
-      .finally(() => setLoading(false));
-  }, [orgSlug]);
 
-  if (loading) return <div className="p-8 text-center">Loading...</div>;
-  if (error) return <div className="p-8 text-center text-red-600">{error}</div>;
-  if (!org) return null;
+    if (error) {
+        return (
+            <div className="mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center px-6">
+                <div className="rounded-2xl border border-destructive/30 bg-card p-8 text-center shadow-elevated">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-destructive/10 text-destructive">
+                        <AlertCircle className="h-6 w-6" />
+                    </div>
+                    <h1 className="mt-4 text-xl font-semibold tracking-tight">Couldn&apos;t load org</h1>
+                    <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+                </div>
+            </div>
+        );
+    }
 
-  return (
-    <div className="max-w-md mx-auto mt-12 p-6 bg-white rounded shadow">
-      <h1 className="text-2xl font-bold mb-2">Join {org.name}</h1>
-      <p className="mb-6 text-gray-600">Enter your info to join this organization.</p>
-      <JoinOrgForm orgSlug={orgSlug!} />
-    </div>
-  );
+    if (!org) return null;
+
+    return (
+        <div className="mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center px-6 py-12">
+            <div className="w-full rounded-2xl border border-border/80 bg-card p-8 shadow-elevated">
+                <div className="flex items-center justify-center">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                        <Users className="h-6 w-6" />
+                    </div>
+                </div>
+                <h1 className="mt-5 text-center text-2xl font-semibold tracking-tight">
+                    Join {org.name}
+                </h1>
+                <p className="mt-2 text-center text-sm text-muted-foreground">
+                    Enter your info below to become a member.
+                </p>
+                <div className="mt-6">
+                    <JoinOrgForm orgSlug={orgSlug!} />
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export default function JoinPage() {
-  return (
-    <Suspense fallback={<div className="p-8 text-center">Loading...</div>}>
-      <JoinPageContent />
-    </Suspense>
-  );
+    return (
+        <AnimatedBackground variant="hero">
+            <Suspense
+                fallback={
+                    <div className="flex min-h-screen items-center justify-center">
+                        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                    </div>
+                }
+            >
+                <JoinPageContent />
+            </Suspense>
+        </AnimatedBackground>
+    );
 }

--- a/src/app/mass-text/page.tsx
+++ b/src/app/mass-text/page.tsx
@@ -1093,61 +1093,89 @@ export default function MassTextPage() {
 
   return (
     <AnimatedBackground>
-      <div className={`container mx-auto p-4 ${viewMode === 'contacts-management' ? 'max-w-6xl' : 'max-w-4xl'}`}>
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl font-bold">Mass Communication</h1>
-          <div className="flex space-x-2">
+      <div className={`container mx-auto px-4 sm:px-6 py-6 sm:py-10 ${viewMode === 'contacts-management' ? 'max-w-6xl' : 'max-w-5xl'}`}>
+        {/* Header */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between mb-8">
+          <div>
+            <div className="flex items-center gap-2">
+              <div className="h-6 w-6 rounded-md bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500 shadow-sm shadow-violet-500/30" />
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                {orgInfo?.name ?? 'Dashboard'}
+              </span>
+            </div>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Communications</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Compose, send, and manage messages and members.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
             <Button
               variant="outline"
               onClick={() => router.push('/sent-messages')}
-              className="flex items-center space-x-2"
             >
               <MessageSquare className="h-4 w-4" />
-              <span>View Sent Messages</span>
+              History
             </Button>
             <Button variant="outline" onClick={() => setShowQrModal(true)} disabled={!orgInfo}>
-              Generate Join QR Code
+              Join QR
             </Button>
           </div>
         </div>
+
         {/* QR Modal */}
         {showQrModal && orgInfo && (
-          <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-            <div className="bg-white rounded-lg shadow-lg p-6 relative w-full max-w-md">
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40 backdrop-blur-sm p-4"
+            onClick={() => setShowQrModal(false)}
+          >
+            <div
+              className="relative w-full max-w-md rounded-2xl border border-border/80 bg-card p-6 shadow-elevated"
+              onClick={(e) => e.stopPropagation()}
+            >
               <button
-                className="absolute top-2 right-2 text-gray-400 hover:text-gray-600"
+                className="absolute right-3 top-3 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 onClick={() => setShowQrModal(false)}
                 aria-label="Close"
               >
-                ×
+                <XCircleIcon className="h-5 w-5" />
               </button>
               <OrgQrCode orgName={orgInfo.name} joinUrl={joinUrl} />
             </div>
           </div>
         )}
-        <div className="flex mb-6 border rounded-lg overflow-hidden">
-          <button
-            className={`flex-1 py-2 ${viewMode === 'mass-text' ? 'bg-primary text-white' : 'bg-gray-100 hover:bg-gray-200'}`}
-            onClick={() => setViewMode('mass-text')}
-          >
-            Mass Text & Email
-          </button>
-          <button
-            className={`flex-1 py-2 ${viewMode === 'contacts-management' ? 'bg-primary text-white' : 'bg-gray-100 hover:bg-gray-200'}`}
-            onClick={() => {
-              setViewMode('contacts-management')
-              setShowContactsList(true)
-              fetchContactsFromSupabase()
-            }}
-          >
-            All Members
-          </button>
-          <button
-            className={`flex-1 py-2 ${viewMode === 'events' ? 'bg-primary text-white' : 'bg-gray-100 hover:bg-gray-200'}`}
-            onClick={() => setViewMode('events')}
-          >
-            Events
-          </button>
+
+        {/* Tabs */}
+        <div className="mb-8 inline-flex w-full items-center rounded-xl border border-border/80 bg-muted/40 p-1 sm:w-auto">
+          {[
+            { key: 'mass-text', label: 'Compose', icon: MessageSquare },
+            { key: 'contacts-management', label: 'Members', icon: Database },
+            { key: 'events', label: 'Events', icon: InfoIcon },
+          ].map((tab) => {
+            const Icon = tab.icon;
+            const active = viewMode === tab.key;
+            return (
+              <button
+                key={tab.key}
+                className={`relative flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-all sm:flex-initial ${
+                  active
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => {
+                  if (tab.key === 'contacts-management') {
+                    setViewMode('contacts-management');
+                    setShowContactsList(true);
+                    fetchContactsFromSupabase();
+                  } else {
+                    setViewMode(tab.key as 'mass-text' | 'contacts-management' | 'events');
+                  }
+                }}
+              >
+                <Icon className="h-4 w-4" />
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
 
         {viewMode === 'mass-text' ? (

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,18 +1,35 @@
 import { OrganizationRegisterForm } from '@/components/OrganizationRegisterForm';
+import AnimatedBackground from '@/components/AnimatedBackground';
 import { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
 
 export const metadata: Metadata = {
-  title: 'Register Organization - Mass Texter',
-  description: 'Register your organization with Mass Texter',
+    title: 'Register Organization · Blitz',
+    description: 'Register your organization with Blitz',
 };
 
 export default function RegisterPage() {
-  return (
-    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-b from-gray-900 to-black">
-      <div className="w-full max-w-md">
-        <h1 className="text-3xl font-bold text-center text-white mb-8">Register Your Organization</h1>
-        <OrganizationRegisterForm />
-      </div>
-    </div>
-  );
-} 
+    return (
+        <AnimatedBackground variant="hero">
+            <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center px-6 py-12">
+                <Link
+                    href="/"
+                    className="absolute left-6 top-6 inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    Home
+                </Link>
+                <div className="w-full">
+                    <OrganizationRegisterForm />
+                    <p className="mt-6 text-center text-sm text-muted-foreground">
+                        Already have an organization?{' '}
+                        <Link href="/access-code" className="font-medium text-primary hover:underline">
+                            Sign in
+                        </Link>
+                    </p>
+                </div>
+            </div>
+        </AnimatedBackground>
+    );
+}

--- a/src/app/sent-messages/page.tsx
+++ b/src/app/sent-messages/page.tsx
@@ -3,390 +3,409 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
-import { Search, Mail, MessageSquare, Calendar, ArrowLeft, ChevronLeft, ChevronRight, ChevronDown, ChevronUp } from 'lucide-react';
+import { Search, Mail, MessageSquare, Calendar, ArrowLeft, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
 import AnimatedBackground from '@/components/AnimatedBackground';
 
 interface TextMessage {
-  id: number;
-  created_at: string;
-  content: string;
-  receiver: string;
+    id: number;
+    created_at: string;
+    content: string;
+    receiver: string;
 }
 
 interface EmailMessage {
-  id: number;
-  created_at: string;
-  content: string;
-  subject: string;
-  receiver: string;
+    id: number;
+    created_at: string;
+    content: string;
+    subject: string;
+    receiver: string;
 }
 
 interface SentMessagesData {
-  texts: TextMessage[];
-  emails: EmailMessage[];
-  pagination: {
-    page: number;
-    limit: number;
-    totalTexts: number;
-    totalEmails: number;
-    totalPagesTexts: number;
-    totalPagesEmails: number;
-  };
+    texts: TextMessage[];
+    emails: EmailMessage[];
+    pagination: {
+        page: number;
+        limit: number;
+        totalTexts: number;
+        totalEmails: number;
+        totalPagesTexts: number;
+        totalPagesEmails: number;
+    };
 }
 
 export default function SentMessagesPage() {
-  const router = useRouter();
-  const [data, setData] = useState<SentMessagesData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [activeTab, setActiveTab] = useState<'texts' | 'emails'>('texts');
-  const [currentPage, setCurrentPage] = useState(1);
-  const [orgInfo, setOrgInfo] = useState<{ id: number; name: string } | null>(null);
-  const [expandedEmails, setExpandedEmails] = useState<Set<number>>(new Set());
+    const router = useRouter();
+    const [data, setData] = useState<SentMessagesData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [activeTab, setActiveTab] = useState<'texts' | 'emails'>('texts');
+    const [currentPage, setCurrentPage] = useState(1);
+    const [orgInfo, setOrgInfo] = useState<{ id: number; name: string } | null>(null);
+    const [expandedEmails, setExpandedEmails] = useState<Set<number>>(new Set());
 
-  // Fetch organization info and verify authentication
-  useEffect(() => {
-    const verifyAuth = async () => {
-      try {
-        const response = await fetch('/api/verify-auth', {
-          method: 'GET',
-          credentials: 'include',
-        });
-        
-        if (!response.ok) {
-          router.push('/');
-          return;
-        }
+    useEffect(() => {
+        const verifyAuth = async () => {
+            try {
+                const response = await fetch('/api/verify-auth', {
+                    method: 'GET',
+                    credentials: 'include',
+                });
 
-        const authData = await response.json();
-        if (authData.success) {
-          setOrgInfo({
-            id: authData.organizationId,
-            name: authData.chapterName
-          });
+                if (!response.ok) {
+                    router.push('/');
+                    return;
+                }
+
+                const authData = await response.json();
+                if (authData.success) {
+                    setOrgInfo({
+                        id: authData.organizationId,
+                        name: authData.chapterName,
+                    });
+                }
+            } catch {
+                router.push('/');
+            }
+        };
+
+        verifyAuth();
+    }, [router]);
+
+    const fetchData = async (page = 1, type: 'texts' | 'emails' | 'all' = 'all') => {
+        try {
+            setLoading(true);
+            const response = await fetch(`/api/sent-messages?type=${type}&page=${page}&limit=20`, {
+                credentials: 'include',
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch data');
+            }
+
+            const result = await response.json();
+            if (result.success) {
+                setData(result.data);
+            }
+        } catch (error) {
+            console.error('Error fetching sent messages:', error);
+        } finally {
+            setLoading(false);
         }
-      } catch {
-        router.push('/');
-      }
     };
 
-    verifyAuth();
-  }, [router]);
+    useEffect(() => {
+        if (orgInfo) {
+            fetchData(currentPage, 'all');
+        }
+    }, [orgInfo, currentPage]);
 
-  // Fetch sent messages data
-  const fetchData = async (page = 1, type: 'texts' | 'emails' | 'all' = 'all') => {
-    try {
-      setLoading(true);
-      const response = await fetch(`/api/sent-messages?type=${type}&page=${page}&limit=20`, {
-        credentials: 'include',
-      });
+    const formatDate = (dateString: string) => {
+        return new Date(dateString).toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    };
 
-      if (!response.ok) {
-        throw new Error('Failed to fetch data');
-      }
+    const filteredTexts =
+        data?.texts.filter(
+            (text) =>
+                text.content.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                text.receiver.toLowerCase().includes(searchTerm.toLowerCase())
+        ) || [];
 
-      const result = await response.json();
-      if (result.success) {
-        setData(result.data);
-      }
-    } catch (error) {
-      console.error('Error fetching sent messages:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
+    const filteredEmails =
+        data?.emails.filter(
+            (email) =>
+                email.content.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                email.subject.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                email.receiver.toLowerCase().includes(searchTerm.toLowerCase())
+        ) || [];
 
-  useEffect(() => {
-    if (orgInfo) {
-      fetchData(currentPage, 'all');
-    }
-  }, [orgInfo, currentPage]);
+    const handlePageChange = (newPage: number, type: 'texts' | 'emails') => {
+        setCurrentPage(newPage);
+        fetchData(newPage, type);
+    };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
+    const toggleEmailExpansion = (emailId: number) => {
+        setExpandedEmails((prev) => {
+            const newSet = new Set(prev);
+            if (newSet.has(emailId)) {
+                newSet.delete(emailId);
+            } else {
+                newSet.add(emailId);
+            }
+            return newSet;
+        });
+    };
 
+    const PaginationControls = ({
+        currentPage,
+        totalPages,
+        onPageChange,
+        type,
+    }: {
+        currentPage: number;
+        totalPages: number;
+        onPageChange: (page: number, type: 'texts' | 'emails') => void;
+        type: 'texts' | 'emails';
+    }) => {
+        if (totalPages <= 1) return null;
 
+        return (
+            <div className="mt-6 flex items-center justify-center gap-2">
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(currentPage - 1, type)}
+                    disabled={currentPage <= 1}
+                >
+                    <ChevronLeft className="h-4 w-4" />
+                    Previous
+                </Button>
 
-  const filteredTexts = data?.texts.filter(text =>
-    text.content.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    text.receiver.toLowerCase().includes(searchTerm.toLowerCase())
-  ) || [];
+                <span className="px-3 text-sm text-muted-foreground">
+                    Page {currentPage} of {totalPages}
+                </span>
 
-  const filteredEmails = data?.emails.filter(email =>
-    email.content.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    email.subject.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    email.receiver.toLowerCase().includes(searchTerm.toLowerCase())
-  ) || [];
-
-  const handlePageChange = (newPage: number, type: 'texts' | 'emails') => {
-    setCurrentPage(newPage);
-    fetchData(newPage, type);
-  };
-
-  const toggleEmailExpansion = (emailId: number) => {
-    setExpandedEmails(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(emailId)) {
-        newSet.delete(emailId);
-      } else {
-        newSet.add(emailId);
-      }
-      return newSet;
-    });
-  };
-
-  const PaginationControls = ({ 
-    currentPage, 
-    totalPages, 
-    onPageChange, 
-    type 
-  }: { 
-    currentPage: number; 
-    totalPages: number; 
-    onPageChange: (page: number, type: 'texts' | 'emails') => void;
-    type: 'texts' | 'emails';
-  }) => {
-    if (totalPages <= 1) return null;
-
-    return (
-      <div className="flex items-center justify-center space-x-2 mt-4">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(currentPage - 1, type)}
-          disabled={currentPage <= 1}
-        >
-          <ChevronLeft className="h-4 w-4" />
-          Previous
-        </Button>
-        
-        <span className="text-sm text-muted-foreground">
-          Page {currentPage} of {totalPages}
-        </span>
-        
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(currentPage + 1, type)}
-          disabled={currentPage >= totalPages}
-        >
-          Next
-          <ChevronRight className="h-4 w-4" />
-        </Button>
-      </div>
-    );
-  };
-
-  if (loading && !data) {
-    return (
-      <AnimatedBackground>
-        <div className="container mx-auto p-4 max-w-4xl flex items-center justify-center min-h-screen">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto mb-4"></div>
-            <p className="text-gray-600">Loading sent messages...</p>
-          </div>
-        </div>
-      </AnimatedBackground>
-    );
-  }
-
-  return (
-    <AnimatedBackground>
-      <div className="container mx-auto p-4 max-w-4xl">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl font-bold">Sent Messages</h1>
-          <Button
-            variant="outline"
-            onClick={() => router.push('/mass-text')}
-            className="flex items-center space-x-2"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back to Dashboard</span>
-          </Button>
-        </div>
-        
-        {orgInfo?.name && (
-          <p className="text-gray-600 mb-6">
-            View all messages sent by {orgInfo.name}
-          </p>
-        )}
-
-        {/* Search */}
-        <Card className="mb-6">
-          <CardContent className="pt-6">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-              <Input
-                placeholder="Search messages, recipients (phone/email), or content..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10"
-              />
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(currentPage + 1, type)}
+                    disabled={currentPage >= totalPages}
+                >
+                    Next
+                    <ChevronRight className="h-4 w-4" />
+                </Button>
             </div>
-          </CardContent>
-        </Card>
+        );
+    };
 
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Total Text Messages</CardTitle>
-              <MessageSquare className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{data?.pagination.totalTexts || 0}</div>
-              <p className="text-xs text-muted-foreground">
-                Messages sent to your organization members
-              </p>
-            </CardContent>
-          </Card>
-          
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Total Emails</CardTitle>
-              <Mail className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{data?.pagination.totalEmails || 0}</div>
-              <p className="text-xs text-muted-foreground">
-                Emails sent to your organization members
-              </p>
-            </CardContent>
-          </Card>
-        </div>
+    if (loading && !data) {
+        return (
+            <AnimatedBackground>
+                <div className="flex min-h-screen items-center justify-center">
+                    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+                        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                        <p className="text-sm">Loading sent messages…</p>
+                    </div>
+                </div>
+            </AnimatedBackground>
+        );
+    }
 
-        {/* Messages Tabs */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Message History</CardTitle>
-            <CardDescription>
-              Browse through all text messages and emails sent by your organization
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'texts' | 'emails')}>
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="texts" className="flex items-center space-x-2">
-                  <MessageSquare className="h-4 w-4" />
-                  <span>Text Messages ({filteredTexts.length})</span>
-                </TabsTrigger>
-                <TabsTrigger value="emails" className="flex items-center space-x-2">
-                  <Mail className="h-4 w-4" />
-                  <span>Emails ({filteredEmails.length})</span>
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="texts" className="space-y-4">
-                {filteredTexts.length === 0 ? (
-                  <div className="text-center py-8">
-                    <MessageSquare className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-                    <p className="text-gray-500">No text messages found.</p>
-                  </div>
-                ) : (
-                  <>
-                    {filteredTexts.map((text) => (
-                      <Card key={text.id} className="p-4">
-                        <div className="flex justify-between items-start mb-2">
-                          <div className="flex items-center space-x-2">
-                            <MessageSquare className="h-4 w-4 text-gray-400" />
-                            <span className="font-semibold">
-                              {text.receiver}
-                            </span>
-                          </div>
-                          <div className="flex items-center space-x-2 text-sm text-gray-500">
-                            <Calendar className="h-4 w-4" />
-                            <span>{formatDate(text.created_at)}</span>
-                          </div>
-                        </div>
-                        <div className="bg-gray-50 rounded-lg p-3">
-                          <p className="text-gray-700">{text.content}</p>
-                        </div>
-                      </Card>
-                    ))}
-                    <PaginationControls
-                      currentPage={currentPage}
-                      totalPages={data?.pagination.totalPagesTexts || 1}
-                      onPageChange={handlePageChange}
-                      type="texts"
-                    />
-                  </>
-                )}
-              </TabsContent>
-
-              <TabsContent value="emails" className="space-y-4">
-                {filteredEmails.length === 0 ? (
-                  <div className="text-center py-8">
-                    <Mail className="h-12 w-12 text-gray-300 mx-auto mb-4" />
-                    <p className="text-gray-500">No emails found.</p>
-                  </div>
-                ) : (
-                  <>
-                    {filteredEmails.map((email) => {
-                      const isExpanded = expandedEmails.has(email.id);
-                      return (
-                        <Card key={email.id} className="p-4">
-                          <div className="flex justify-between items-start mb-2">
-                            <div className="flex items-center space-x-2">
-                              <Mail className="h-4 w-4 text-gray-400" />
-                              <span className="font-semibold">
-                                {email.receiver}
-                              </span>
-                            </div>
-                            <div className="flex items-center space-x-2 text-sm text-gray-500">
-                              <Calendar className="h-4 w-4" />
-                              <span>{formatDate(email.created_at)}</span>
-                            </div>
-                          </div>
-                          <div className="mb-2">
-                            <h4 className="font-semibold text-gray-900">Subject: {email.subject}</h4>
-                          </div>
-                          <Button
+    return (
+        <AnimatedBackground>
+            <div className="mx-auto w-full max-w-5xl px-6 py-8 sm:py-12">
+                {/* Header */}
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => toggleEmailExpansion(email.id)}
-                            className="w-full justify-between p-2 h-auto text-left hover:bg-gray-50"
-                          >
-                            <span className="text-sm text-gray-600">
-                              {isExpanded ? 'Hide email content' : 'View email content'}
-                            </span>
-                            {isExpanded ? (
-                              <ChevronUp className="h-4 w-4" />
-                            ) : (
-                              <ChevronDown className="h-4 w-4" />
-                            )}
-                          </Button>
-                          {isExpanded && (
-                            <div className="mt-2 bg-gray-50 rounded-lg p-3">
-                              <p className="text-gray-700 whitespace-pre-wrap">{email.content}</p>
+                            onClick={() => router.push('/mass-text')}
+                            className="-ml-2 mb-2 text-muted-foreground hover:text-foreground"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                            Dashboard
+                        </Button>
+                        <h1 className="text-3xl font-semibold tracking-tight">Message history</h1>
+                        {orgInfo?.name && (
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                All messages sent by {orgInfo.name}
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                {/* Stats */}
+                <div className="mt-8 grid gap-4 sm:grid-cols-2">
+                    <div className="rounded-xl border border-border/80 bg-card p-5 shadow-soft">
+                        <div className="flex items-center justify-between">
+                            <p className="text-sm font-medium text-muted-foreground">Text messages</p>
+                            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-primary">
+                                <MessageSquare className="h-4 w-4" />
                             </div>
-                          )}
-                        </Card>
-                      );
-                    })}
-                    <PaginationControls
-                      currentPage={currentPage}
-                      totalPages={data?.pagination.totalPagesEmails || 1}
-                      onPageChange={handlePageChange}
-                      type="emails"
+                        </div>
+                        <p className="mt-3 text-3xl font-semibold tracking-tight">
+                            {data?.pagination.totalTexts || 0}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">All-time delivered</p>
+                    </div>
+                    <div className="rounded-xl border border-border/80 bg-card p-5 shadow-soft">
+                        <div className="flex items-center justify-between">
+                            <p className="text-sm font-medium text-muted-foreground">Emails</p>
+                            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent text-primary">
+                                <Mail className="h-4 w-4" />
+                            </div>
+                        </div>
+                        <p className="mt-3 text-3xl font-semibold tracking-tight">
+                            {data?.pagination.totalEmails || 0}
+                        </p>
+                        <p className="mt-1 text-xs text-muted-foreground">All-time delivered</p>
+                    </div>
+                </div>
+
+                {/* Search */}
+                <div className="mt-6 relative">
+                    <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                        placeholder="Search by content, subject, phone or email…"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="h-11 pl-10"
                     />
-                  </>
-                )}
-              </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
-      </div>
-    </AnimatedBackground>
-  );
+                </div>
+
+                {/* Tabs */}
+                <div className="mt-6 rounded-2xl border border-border/80 bg-card shadow-soft">
+                    <Tabs
+                        value={activeTab}
+                        onValueChange={(value) => setActiveTab(value as 'texts' | 'emails')}
+                        className="p-2"
+                    >
+                        <TabsList className="grid w-full grid-cols-2">
+                            <TabsTrigger value="texts" className="gap-2">
+                                <MessageSquare className="h-4 w-4" />
+                                Texts ({filteredTexts.length})
+                            </TabsTrigger>
+                            <TabsTrigger value="emails" className="gap-2">
+                                <Mail className="h-4 w-4" />
+                                Emails ({filteredEmails.length})
+                            </TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="texts" className="p-2 sm:p-4">
+                            {filteredTexts.length === 0 ? (
+                                <EmptyState
+                                    icon={MessageSquare}
+                                    title="No text messages yet"
+                                    desc="Once you send your first text, it'll show up here."
+                                />
+                            ) : (
+                                <div className="space-y-3">
+                                    {filteredTexts.map((text) => (
+                                        <div
+                                            key={text.id}
+                                            className="rounded-xl border border-border/60 bg-background p-4 transition-colors hover:border-border"
+                                        >
+                                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                                <div className="flex items-center gap-2">
+                                                    <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent text-primary">
+                                                        <MessageSquare className="h-3.5 w-3.5" />
+                                                    </div>
+                                                    <span className="text-sm font-medium">{text.receiver}</span>
+                                                </div>
+                                                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                                    <Calendar className="h-3 w-3" />
+                                                    <span>{formatDate(text.created_at)}</span>
+                                                </div>
+                                            </div>
+                                            <p className="mt-3 rounded-lg bg-muted/50 p-3 text-sm leading-relaxed text-foreground/90">
+                                                {text.content}
+                                            </p>
+                                        </div>
+                                    ))}
+                                    <PaginationControls
+                                        currentPage={currentPage}
+                                        totalPages={data?.pagination.totalPagesTexts || 1}
+                                        onPageChange={handlePageChange}
+                                        type="texts"
+                                    />
+                                </div>
+                            )}
+                        </TabsContent>
+
+                        <TabsContent value="emails" className="p-2 sm:p-4">
+                            {filteredEmails.length === 0 ? (
+                                <EmptyState
+                                    icon={Mail}
+                                    title="No emails yet"
+                                    desc="Once you send your first email, it'll show up here."
+                                />
+                            ) : (
+                                <div className="space-y-3">
+                                    {filteredEmails.map((email) => {
+                                        const isExpanded = expandedEmails.has(email.id);
+                                        return (
+                                            <div
+                                                key={email.id}
+                                                className="rounded-xl border border-border/60 bg-background p-4 transition-colors hover:border-border"
+                                            >
+                                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent text-primary">
+                                                            <Mail className="h-3.5 w-3.5" />
+                                                        </div>
+                                                        <span className="text-sm font-medium">{email.receiver}</span>
+                                                    </div>
+                                                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                                        <Calendar className="h-3 w-3" />
+                                                        <span>{formatDate(email.created_at)}</span>
+                                                    </div>
+                                                </div>
+                                                <div className="mt-3 text-sm font-semibold">{email.subject}</div>
+                                                <button
+                                                    onClick={() => toggleEmailExpansion(email.id)}
+                                                    className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                                                >
+                                                    {isExpanded ? (
+                                                        <>
+                                                            <ChevronUp className="h-3 w-3" />
+                                                            Hide content
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <ChevronDown className="h-3 w-3" />
+                                                            View content
+                                                        </>
+                                                    )}
+                                                </button>
+                                                {isExpanded && (
+                                                    <p className="mt-2 whitespace-pre-wrap rounded-lg bg-muted/50 p-3 text-sm leading-relaxed text-foreground/90">
+                                                        {email.content}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                    <PaginationControls
+                                        currentPage={currentPage}
+                                        totalPages={data?.pagination.totalPagesEmails || 1}
+                                        onPageChange={handlePageChange}
+                                        type="emails"
+                                    />
+                                </div>
+                            )}
+                        </TabsContent>
+                    </Tabs>
+                </div>
+            </div>
+        </AnimatedBackground>
+    );
+}
+
+function EmptyState({
+    icon: Icon,
+    title,
+    desc,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    title: string;
+    desc: string;
+}) {
+    return (
+        <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                <Icon className="h-5 w-5" />
+            </div>
+            <h3 className="mt-4 text-base font-semibold">{title}</h3>
+            <p className="mt-1 max-w-xs text-sm text-muted-foreground">{desc}</p>
+        </div>
+    );
 }

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -4,64 +4,98 @@ import { motion } from 'framer-motion';
 
 export default function AnimatedBackground({
     children,
-    zIndex = 5,
+    zIndex = 0,
+    variant = 'subtle',
 }: {
     children: React.ReactNode;
     zIndex?: number;
+    variant?: 'subtle' | 'hero';
 }) {
     return (
-        <div className="relative min-h-screen">
-            {children}
+        <div className="relative min-h-screen bg-background">
             <div
-                className="pointer-events-none fixed inset-0 overflow-hidden"
+                className="pointer-events-none absolute inset-0 overflow-hidden"
                 style={{ zIndex }}
+                aria-hidden="true"
             >
-                <motion.div
-                    className="absolute top-[-5%] left-[-2.5%] w-[250px] h-[250px] sm:w-[350px] sm:h-[350px] md:w-[500px] md:h-[500px] md:top-[-10%] md:left-[-5%] rounded-full bg-gray-800 opacity-20 blur-[20px] sm:blur-[30px] md:blur-[40px]"
-                    animate={{
-                        scale: [1, 1.2, 1],
-                        opacity: [0.2, 0.3, 0.2],
-                        x: [0, 100, -50, 0],
-                        y: [0, -100, 50, 0],
-                    }}
-                    transition={{
-                        duration: 15,
-                        repeat: Infinity,
-                        repeatType: "reverse",
-                        ease: "easeInOut",
-                    }}
-                />
-                <motion.div
-                    className="absolute bottom-[-5%] right-[-2.5%] w-[250px] h-[250px] sm:w-[350px] sm:h-[350px] md:w-[500px] md:h-[500px] md:bottom-[-10%] md:right-[-5%] rounded-full bg-black opacity-20 blur-[20px] sm:blur-[30px] md:blur-[40px]"
-                    animate={{
-                        scale: [1, 1.3, 1],
-                        opacity: [0.2, 0.35, 0.2],
-                        x: [0, -150, 100, 0],
-                        y: [0, 150, -100, 0],
-                    }}
-                    transition={{
-                        duration: 20,
-                        repeat: Infinity,
-                        repeatType: "reverse",
-                        ease: "easeInOut",
-                    }}
-                />
-                <motion.div
-                    className="absolute top-[30%] left-[20%] w-[200px] h-[200px] sm:w-[300px] sm:h-[300px] md:w-[400px] md:h-[400px] rounded-full bg-gray-900 opacity-20 blur-[20px] sm:blur-[30px] md:blur-[40px]"
-                    animate={{
-                        scale: [1, 1.1, 1],
-                        opacity: [0.2, 0.25, 0.2],
-                        x: [0, 80, -120, 0],
-                        y: [0, -80, 120, 0],
-                    }}
-                    transition={{
-                        duration: 18,
-                        repeat: Infinity,
-                        repeatType: "reverse",
-                        ease: "easeInOut",
-                    }}
-                />
+                {/* Layer 1: subtle dot grid */}
+                <div className="absolute inset-0 bg-grid bg-grid-fade opacity-60" />
+
+                {/* Layer 2: ambient glow blobs */}
+                {variant === 'hero' ? (
+                    <>
+                        <motion.div
+                            className="absolute -top-40 left-1/2 -translate-x-1/2 h-[600px] w-[900px] rounded-full opacity-40 blur-3xl"
+                            style={{
+                                background:
+                                    'radial-gradient(ellipse at center, oklch(0.6 0.22 285 / 0.45), transparent 60%)',
+                            }}
+                            animate={{
+                                scale: [1, 1.05, 1],
+                                opacity: [0.35, 0.5, 0.35],
+                            }}
+                            transition={{
+                                duration: 12,
+                                repeat: Infinity,
+                                ease: 'easeInOut',
+                            }}
+                        />
+                        <motion.div
+                            className="absolute top-1/3 -left-20 h-[400px] w-[500px] rounded-full opacity-30 blur-3xl"
+                            style={{
+                                background:
+                                    'radial-gradient(ellipse at center, oklch(0.65 0.18 230 / 0.4), transparent 60%)',
+                            }}
+                            animate={{
+                                scale: [1, 1.1, 1],
+                                x: [0, 30, 0],
+                                y: [0, -20, 0],
+                            }}
+                            transition={{
+                                duration: 18,
+                                repeat: Infinity,
+                                ease: 'easeInOut',
+                            }}
+                        />
+                        <motion.div
+                            className="absolute bottom-0 right-0 h-[400px] w-[500px] rounded-full opacity-30 blur-3xl"
+                            style={{
+                                background:
+                                    'radial-gradient(ellipse at center, oklch(0.68 0.18 320 / 0.4), transparent 60%)',
+                            }}
+                            animate={{
+                                scale: [1, 1.08, 1],
+                                x: [0, -20, 0],
+                                y: [0, 20, 0],
+                            }}
+                            transition={{
+                                duration: 16,
+                                repeat: Infinity,
+                                ease: 'easeInOut',
+                            }}
+                        />
+                    </>
+                ) : (
+                    <>
+                        <div
+                            className="absolute -top-40 right-0 h-[400px] w-[600px] rounded-full opacity-25 blur-3xl"
+                            style={{
+                                background:
+                                    'radial-gradient(ellipse at center, oklch(0.65 0.18 280 / 0.35), transparent 60%)',
+                            }}
+                        />
+                        <div
+                            className="absolute top-1/2 -left-20 h-[300px] w-[400px] rounded-full opacity-20 blur-3xl"
+                            style={{
+                                background:
+                                    'radial-gradient(ellipse at center, oklch(0.7 0.15 230 / 0.3), transparent 60%)',
+                            }}
+                        />
+                    </>
+                )}
             </div>
+
+            <div className="relative z-10">{children}</div>
         </div>
     );
-} 
+}

--- a/src/components/GetStartedDialog.tsx
+++ b/src/components/GetStartedDialog.tsx
@@ -1,7 +1,8 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { motion, AnimatePresence } from 'framer-motion';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { ArrowRight, Building2, KeyRound } from 'lucide-react';
 
 interface GetStartedDialogProps {
     isOpen: boolean;
@@ -12,46 +13,52 @@ export function GetStartedDialog({ isOpen, onClose }: GetStartedDialogProps) {
     const router = useRouter();
 
     const handleNavigation = (path: string) => {
-        // Use a smoother transition with Framer Motion
-        setTimeout(() => {
-            onClose();
-            router.push(path);
-        }, 500); // Slightly longer for smoother transition
+        onClose();
+        setTimeout(() => router.push(path), 100);
     };
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <AnimatePresence>
-                {isOpen && (
-                    <DialogContent className="sm:max-w-md max-w-[90%] overflow-hidden border border-gray-100 bg-white/90 backdrop-blur-sm p-6">
-                        <motion.div
-                            initial={{ opacity: 0, scale: 0.9 }}
-                            animate={{ opacity: 1, scale: 1 }}
-                            exit={{ opacity: 0, scale: 0.95 }}
-                            transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
-                        >
-                            <DialogHeader className="mb-4">
-                                <DialogTitle className="text-center text-xl font-bold">Welcome to Mass Texter</DialogTitle>
-                            </DialogHeader>
-                            <div className="flex flex-col gap-4 py-4">
-                                <Button 
-                                    variant="outline" 
-                                    className="w-full h-12 text-base border-gray-300 hover:bg-gray-100 transition-colors"
-                                    onClick={() => handleNavigation('/access-code')}
-                                >
-                                    Already have an organization
-                                </Button>
-                                <Button 
-                                    className="w-full h-12 text-base bg-gradient-to-r from-blue-600 via-purple-500 to-blue-800 hover:opacity-90 transition-opacity text-white"
-                                    onClick={() => handleNavigation('/register')}
-                                >
-                                    Register organization
-                                </Button>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="text-xl">Welcome to Blitz</DialogTitle>
+                    <DialogDescription>
+                        Pick how you&apos;d like to get started.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="mt-2 grid gap-3">
+                    <button
+                        onClick={() => handleNavigation('/access-code')}
+                        className="group flex items-center gap-4 rounded-xl border border-border/80 bg-surface p-4 text-left transition-all hover:border-primary/40 hover:bg-accent/50"
+                    >
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent text-primary">
+                            <KeyRound className="h-5 w-5" />
+                        </div>
+                        <div className="flex-1">
+                            <div className="font-medium">Sign in to existing org</div>
+                            <div className="text-xs text-muted-foreground">
+                                Use your access code
                             </div>
-                        </motion.div>
-                    </DialogContent>
-                )}
-            </AnimatePresence>
+                        </div>
+                        <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                    </button>
+                    <button
+                        onClick={() => handleNavigation('/register')}
+                        className="group flex items-center gap-4 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 p-4 text-left transition-all hover:border-primary/50"
+                    >
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
+                            <Building2 className="h-5 w-5" />
+                        </div>
+                        <div className="flex-1">
+                            <div className="font-medium">Register new organization</div>
+                            <div className="text-xs text-muted-foreground">
+                                Set things up in under a minute
+                            </div>
+                        </div>
+                        <ArrowRight className="h-4 w-4 text-primary transition-transform group-hover:translate-x-0.5" />
+                    </button>
+                </div>
+            </DialogContent>
         </Dialog>
     );
-} 
+}

--- a/src/components/JoinOrgForm.tsx
+++ b/src/components/JoinOrgForm.tsx
@@ -1,73 +1,103 @@
-// src/components/JoinOrgForm.tsx
 'use client';
 
 import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { CheckCircle2, Loader2 } from 'lucide-react';
 
 export default function JoinOrgForm({ orgSlug }: { orgSlug: string }) {
-  const [form, setForm] = useState({ name: '', email: '', phone: '' });
-  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
-  const [error, setError] = useState<string | null>(null);
+    const [form, setForm] = useState({ name: '', email: '', phone: '' });
+    const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+    const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+    };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setStatus('submitting');
-    setError(null);
-    const res = await fetch('/api/join-org', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, orgSlug }),
-    });
-    const data = await res.json();
-    if (res.ok) setStatus('success');
-    else {
-      setStatus('error');
-      setError(data.error || 'Failed to join organization.');
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setStatus('submitting');
+        setError(null);
+        const res = await fetch('/api/join-org', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...form, orgSlug }),
+        });
+        const data = await res.json();
+        if (res.ok) setStatus('success');
+        else {
+            setStatus('error');
+            setError(data.error || 'Failed to join organization.');
+        }
+    };
+
+    if (status === 'success') {
+        return (
+            <div className="flex flex-col items-center text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
+                    <CheckCircle2 className="h-6 w-6" />
+                </div>
+                <p className="mt-4 text-base font-medium">You&apos;re in!</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                    You&apos;ve been added to the organization.
+                </p>
+            </div>
+        );
     }
-  };
 
-  if (status === 'success') {
-    return <div className="p-4 text-green-600">You have been added to the organization!</div>;
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <input
-        name="name"
-        placeholder="Full Name"
-        className="w-full border p-2 rounded"
-        value={form.name}
-        onChange={handleChange}
-        required
-      />
-      <input
-        name="email"
-        type="email"
-        placeholder="Email"
-        className="w-full border p-2 rounded"
-        value={form.email}
-        onChange={handleChange}
-        required
-      />
-      <input
-        name="phone"
-        placeholder="Phone"
-        className="w-full border p-2 rounded"
-        value={form.phone}
-        onChange={handleChange}
-        required
-      />
-      {error && <div className="text-red-600">{error}</div>}
-      <button
-        type="submit"
-        className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
-        disabled={status === 'submitting'}
-      >
-        {status === 'submitting' ? 'Joining...' : 'Join Organization'}
-      </button>
-    </form>
-  );
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+                <Label htmlFor="name">Full name</Label>
+                <Input
+                    id="name"
+                    name="name"
+                    placeholder="Jane Doe"
+                    value={form.name}
+                    onChange={handleChange}
+                    required
+                />
+            </div>
+            <div className="space-y-1.5">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    placeholder="you@school.edu"
+                    value={form.email}
+                    onChange={handleChange}
+                    required
+                />
+            </div>
+            <div className="space-y-1.5">
+                <Label htmlFor="phone">Phone</Label>
+                <Input
+                    id="phone"
+                    name="phone"
+                    placeholder="+1 555 555 5555"
+                    value={form.phone}
+                    onChange={handleChange}
+                    required
+                />
+            </div>
+            {error && (
+                <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+            <Button type="submit" size="lg" className="w-full" disabled={status === 'submitting'}>
+                {status === 'submitting' ? (
+                    <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Joining…
+                    </>
+                ) : (
+                    'Join organization'
+                )}
+            </Button>
+        </form>
+    );
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,82 +1,248 @@
 'use client';
 
 import { Fragment, useState } from 'react';
-import { LandingAnimation } from './LandingAnimation';
 import { motion } from 'framer-motion';
 import { GetStartedDialog } from './GetStartedDialog';
 import Link from 'next/link';
 import AnimatedBackground from './AnimatedBackground';
+import { ArrowRight, MessageSquare, Mail, Users, Zap, Calendar, Shield } from 'lucide-react';
+
+const features = [
+    { icon: MessageSquare, title: 'Mass SMS', desc: 'Send personalized texts to thousands in seconds.' },
+    { icon: Mail, title: 'Beautiful Email', desc: 'AI-crafted emails with templated layouts.' },
+    { icon: Users, title: 'Smart Contacts', desc: 'CSV upload, opt-out handling, deduplication.' },
+    { icon: Calendar, title: 'Event Check‑In', desc: 'QR-based attendance with live attendee lists.' },
+    { icon: Zap, title: 'AI Assistant', desc: 'Compose and refine messages with one click.' },
+    { icon: Shield, title: 'Compliant by default', desc: '10DLC, opt-out, and per-org rate limits.' },
+];
 
 export function LandingPage() {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
 
     return (
         <Fragment>
-            {/* Hide animation on mobile screens */}
-            <div className="hidden sm:block">
-                <LandingAnimation />
-            </div>
-            
-            <AnimatedBackground>
-                <div className="relative min-h-screen w-full bg-transparent text-black sm:text-black text-white flex flex-col items-center justify-center z-10">
+            <AnimatedBackground variant="hero">
+                {/* NAV */}
+                <nav className="relative z-20 mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-6">
+                    <div className="flex items-center gap-2">
+                        <div className="h-7 w-7 rounded-lg bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500 shadow-md shadow-violet-500/30" />
+                        <span className="text-lg font-semibold tracking-tight">Blitz</span>
+                    </div>
+                    <div className="flex items-center gap-1 sm:gap-2">
+                        <Link
+                            href="/about"
+                            className="rounded-lg px-3 py-2 text-sm font-medium text-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+                        >
+                            About
+                        </Link>
+                        <button
+                            onClick={() => setIsDialogOpen(true)}
+                            className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background shadow-sm transition-all hover:bg-foreground/90 hover:shadow-md"
+                        >
+                            Get started
+                        </button>
+                    </div>
+                </nav>
+
+                {/* HERO */}
+                <section className="relative mx-auto flex w-full max-w-6xl flex-col items-center px-6 pt-12 pb-20 sm:pt-20 sm:pb-28">
                     <motion.div
-                        initial={{ opacity: 0, scale: 0.95 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        transition={{ duration: 0.8 }}
-                        className="text-center px-4 relative max-w-xl mx-auto"
+                        initial={{ opacity: 0, y: 12 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+                        className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/80 bg-surface/80 px-3 py-1 text-xs font-medium text-muted-foreground backdrop-blur"
                     >
-                        <div className="mb-8 relative">
-                            <div className="text-6xl md:text-8xl font-bold relative">
-                                <span className="absolute inset-0 bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent animate-gradient">
-                                    Blitz
-                                </span>
-                                <span className="invisible">Blitz</span>
+                        <span className="relative flex h-2 w-2">
+                            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                            <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                        </span>
+                        Built for organizations that move fast
+                    </motion.div>
+
+                    <motion.h1
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.7, delay: 0.05, ease: [0.16, 1, 0.3, 1] }}
+                        className="text-center text-5xl font-semibold tracking-tighter sm:text-6xl md:text-7xl lg:text-[88px] lg:leading-[0.95]"
+                    >
+                        Reach every member.
+                        <br />
+                        <span className="brand-wordmark">Instantly.</span>
+                    </motion.h1>
+
+                    <motion.p
+                        initial={{ opacity: 0, y: 16 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.7, delay: 0.15, ease: [0.16, 1, 0.3, 1] }}
+                        className="mt-6 max-w-2xl text-center text-base leading-relaxed text-muted-foreground sm:text-lg md:text-xl"
+                    >
+                        Blitz is the all-in-one communication platform for clubs, chapters, and teams.
+                        Send mass texts, beautiful emails, run events, and manage members — without the chaos.
+                    </motion.p>
+
+                    <motion.div
+                        initial={{ opacity: 0, y: 16 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.7, delay: 0.25, ease: [0.16, 1, 0.3, 1] }}
+                        className="mt-10 flex flex-col items-center gap-3 sm:flex-row"
+                    >
+                        <button
+                            onClick={() => setIsDialogOpen(true)}
+                            className="group inline-flex h-12 items-center gap-2 rounded-xl bg-foreground px-6 text-[15px] font-medium text-background shadow-lg shadow-foreground/20 transition-all hover:shadow-xl hover:shadow-foreground/30 active:scale-[0.98]"
+                        >
+                            Get started free
+                            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                        </button>
+                        <Link
+                            href="/about"
+                            className="inline-flex h-12 items-center gap-2 rounded-xl border border-border/80 bg-surface/80 px-6 text-[15px] font-medium text-foreground backdrop-blur transition-all hover:bg-accent active:scale-[0.98]"
+                        >
+                            See it in action
+                        </Link>
+                    </motion.div>
+
+                    {/* PRODUCT MOCK */}
+                    <motion.div
+                        initial={{ opacity: 0, y: 40 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.9, delay: 0.4, ease: [0.16, 1, 0.3, 1] }}
+                        className="relative mt-16 w-full max-w-5xl"
+                    >
+                        <div className="absolute -inset-x-8 -top-8 -bottom-8 rounded-[32px] bg-gradient-to-b from-violet-500/20 via-transparent to-transparent blur-2xl" />
+                        <div className="relative overflow-hidden rounded-2xl border border-border/80 bg-surface shadow-elevated">
+                            <div className="flex items-center gap-1.5 border-b border-border/80 bg-muted/40 px-4 py-3">
+                                <div className="h-2.5 w-2.5 rounded-full bg-red-400/70" />
+                                <div className="h-2.5 w-2.5 rounded-full bg-amber-400/70" />
+                                <div className="h-2.5 w-2.5 rounded-full bg-emerald-400/70" />
+                                <div className="ml-3 text-xs text-muted-foreground">blitz.app / dashboard</div>
+                            </div>
+                            <div className="grid gap-4 p-6 sm:grid-cols-3">
+                                {[
+                                    { label: 'Members', value: '1,284', delta: '+24 this week' },
+                                    { label: 'Texts sent', value: '8.2k', delta: '+312 today' },
+                                    { label: 'Open rate', value: '94%', delta: 'Email last 7d' },
+                                ].map((stat) => (
+                                    <div
+                                        key={stat.label}
+                                        className="rounded-xl border border-border/60 bg-background p-4"
+                                    >
+                                        <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                            {stat.label}
+                                        </div>
+                                        <div className="mt-2 text-3xl font-semibold tracking-tight">{stat.value}</div>
+                                        <div className="mt-1 text-xs text-emerald-600 dark:text-emerald-400">
+                                            {stat.delta}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                            <div className="grid gap-4 px-6 pb-6 sm:grid-cols-2">
+                                <div className="rounded-xl border border-border/60 bg-background p-5">
+                                    <div className="flex items-center gap-2">
+                                        <MessageSquare className="h-4 w-4 text-primary" />
+                                        <span className="text-sm font-medium">Compose text</span>
+                                    </div>
+                                    <div className="mt-3 rounded-lg bg-muted/60 p-3 text-sm text-foreground/80">
+                                        Hi {'{name}'}! Pizza & politics tonight at 7pm in Engineering 1140. See you there 🍕
+                                    </div>
+                                    <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                                        <span>1,284 recipients</span>
+                                        <span className="rounded-md bg-primary/10 px-2 py-0.5 font-medium text-primary">
+                                            Ready to send
+                                        </span>
+                                    </div>
+                                </div>
+                                <div className="rounded-xl border border-border/60 bg-background p-5">
+                                    <div className="flex items-center gap-2">
+                                        <Calendar className="h-4 w-4 text-primary" />
+                                        <span className="text-sm font-medium">Upcoming event</span>
+                                    </div>
+                                    <div className="mt-3 text-sm font-semibold">Spring Kickoff</div>
+                                    <div className="text-xs text-muted-foreground">Tonight · 7:00 PM</div>
+                                    <div className="mt-3 flex -space-x-2">
+                                        {['oklch(0.7_0.16_30)', 'oklch(0.7_0.16_180)', 'oklch(0.7_0.16_300)', 'oklch(0.7_0.16_120)'].map((c, i) => (
+                                            <div
+                                                key={i}
+                                                className="h-7 w-7 rounded-full border-2 border-background"
+                                                style={{ background: `var(--c, ${c.replace(/_/g, ' ')})` }}
+                                            />
+                                        ))}
+                                        <div className="grid h-7 w-7 place-items-center rounded-full border-2 border-background bg-muted text-[10px] font-semibold text-muted-foreground">
+                                            +42
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                        
-                        <motion.p
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            transition={{ delay: 0.5, duration: 0.8 }}
-                            className="text-xl md:text-2xl font-semibold max-w-2xl mx-auto mb-10 leading-relaxed bg-gradient-to-r from-blue-600 via-purple-600 to-blue-800 bg-clip-text text-transparent animate-gradient"
-                            style={{
-                                WebkitBackgroundClip: 'text',
-                                backgroundClip: 'text',
-                                color: 'transparent',
-                                WebkitTextFillColor: 'transparent',
-                                MozBackgroundClip: 'text',
-                            }}
-                        >
-                            Streamline your communication with powerful mass texting capabilities
-                        </motion.p>
-                        
-                        <motion.div
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ delay: 0.7, duration: 0.8 }}
-                            className="flex flex-row gap-4 justify-center items-center"
-                        >
-                            <button 
-                                onClick={() => setIsDialogOpen(true)}
-                                className="flex-1 max-w-[180px] bg-gradient-to-r from-blue-600 via-purple-500 to-blue-800 text-white px-6 py-4 rounded-xl text-lg font-semibold shadow-lg hover:shadow-purple-600/30 transition-all duration-300 transform hover:scale-105"
-                            >
-                                Get Started
-                            </button>
-                            <Link 
-                                href="/about"
-                                className="flex-1 max-w-[180px] bg-black text-white sm:bg-white sm:text-black px-6 py-4 rounded-xl text-lg font-semibold shadow-lg hover:bg-gray-900 sm:hover:bg-gray-100 transition-all duration-300 transform hover:scale-105 border border-white/40 sm:border-gray-200"
-                            >
-                                About Us
-                            </Link>
-                        </motion.div>
                     </motion.div>
-                </div>
+                </section>
+
+                {/* FEATURES */}
+                <section className="relative mx-auto w-full max-w-6xl px-6 py-20">
+                    <div className="mb-12 max-w-2xl">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-primary">Everything you need</p>
+                        <h2 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
+                            One platform. Every channel.
+                        </h2>
+                        <p className="mt-3 text-base text-muted-foreground">
+                            Stop juggling tools. Blitz combines messaging, member management, and events into a single, refined workspace.
+                        </p>
+                    </div>
+                    <div className="grid gap-px overflow-hidden rounded-2xl border border-border/80 bg-border/80 sm:grid-cols-2 lg:grid-cols-3">
+                        {features.map((f) => (
+                            <div
+                                key={f.title}
+                                className="group flex flex-col gap-3 bg-card p-6 transition-colors hover:bg-accent/40"
+                            >
+                                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent text-primary">
+                                    <f.icon className="h-5 w-5" />
+                                </div>
+                                <div className="text-base font-semibold">{f.title}</div>
+                                <div className="text-sm leading-relaxed text-muted-foreground">{f.desc}</div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                {/* CTA */}
+                <section className="relative mx-auto w-full max-w-6xl px-6 pb-24">
+                    <div className="overflow-hidden rounded-2xl border border-border/80 bg-gradient-to-br from-foreground to-foreground/85 px-8 py-14 text-background shadow-elevated sm:px-14">
+                        <div className="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-center">
+                            <div className="max-w-xl">
+                                <h3 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                                    Ready to send your first blitz?
+                                </h3>
+                                <p className="mt-2 text-sm text-background/70 sm:text-base">
+                                    Set up your organization in minutes. No credit card required.
+                                </p>
+                            </div>
+                            <button
+                                onClick={() => setIsDialogOpen(true)}
+                                className="inline-flex h-12 items-center gap-2 rounded-xl bg-background px-6 text-[15px] font-medium text-foreground shadow-lg transition-all hover:scale-[1.02] active:scale-[0.98]"
+                            >
+                                Create your organization
+                                <ArrowRight className="h-4 w-4" />
+                            </button>
+                        </div>
+                    </div>
+                </section>
+
+                {/* FOOTER */}
+                <footer className="border-t border-border/80 bg-background/50 backdrop-blur">
+                    <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-6 py-8 sm:flex-row">
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <div className="h-5 w-5 rounded-md bg-gradient-to-br from-indigo-500 via-violet-500 to-fuchsia-500" />
+                            <span className="font-medium text-foreground">Blitz</span>
+                            <span>· The communication platform for organizations</span>
+                        </div>
+                        <Link href="/about" className="text-sm text-muted-foreground hover:text-foreground">
+                            About & Contact →
+                        </Link>
+                    </div>
+                </footer>
             </AnimatedBackground>
 
-            <GetStartedDialog 
-                isOpen={isDialogOpen}
-                onClose={() => setIsDialogOpen(false)}
-            />
+            <GetStartedDialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} />
         </Fragment>
     );
-} 
+}

--- a/src/components/OrganizationRegisterForm.tsx
+++ b/src/components/OrganizationRegisterForm.tsx
@@ -7,143 +7,155 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useRouter } from 'next/navigation';
+import { Building2, CheckCircle2, Loader2 } from 'lucide-react';
 
 const formSchema = z.object({
-  organizationName: z.string().min(2, {
-    message: "Organization name must be at least 2 characters.",
-  }),
-  email: z.string().email({
-    message: "Please enter a valid email address.",
-  }),
-  phoneNumber: z.string().regex(/^\+?[0-9]{10,15}$/, {
-    message: "Please enter a valid phone number.",
-  }),
+    organizationName: z.string().min(2, {
+        message: "Organization name must be at least 2 characters.",
+    }),
+    email: z.string().email({
+        message: "Please enter a valid email address.",
+    }),
+    phoneNumber: z.string().regex(/^\+?[0-9]{10,15}$/, {
+        message: "Please enter a valid phone number.",
+    }),
 });
 
 type FormValues = z.infer<typeof formSchema>;
 
 export function OrganizationRegisterForm() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submitSuccess, setSubmitSuccess] = useState(false);
-  const router = useRouter();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+    const [submitSuccess, setSubmitSuccess] = useState(false);
+    const router = useRouter();
 
-  const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
-      organizationName: '',
-      email: '',
-      phoneNumber: '',
-    },
-  });
-
-  const onSubmit = async (data: FormValues) => {
-    setIsSubmitting(true);
-    setSubmitError(null);
-    
-    try {
-      const response = await fetch('/api/register-org', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+    const form = useForm<FormValues>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            organizationName: '',
+            email: '',
+            phoneNumber: '',
         },
-        body: JSON.stringify(data),
-      });
+    });
 
-      const result = await response.json();
+    const onSubmit = async (data: FormValues) => {
+        setIsSubmitting(true);
+        setSubmitError(null);
 
-      if (!response.ok) {
-        throw new Error(result.error || 'Failed to register organization');
-      }
+        try {
+            const response = await fetch('/api/register-org', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data),
+            });
 
-      setSubmitSuccess(true);
-      setTimeout(() => {
-        router.push('/');
-      }, 2000);
-    } catch (error: Error | unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'An error occurred while submitting the form';
-      setSubmitError(errorMessage);
-    } finally {
-      setIsSubmitting(false);
+            const result = await response.json();
+            if (!response.ok) {
+                throw new Error(result.error || 'Failed to register organization');
+            }
+
+            setSubmitSuccess(true);
+            setTimeout(() => router.push('/'), 2000);
+        } catch (error: Error | unknown) {
+            const errorMessage =
+                error instanceof Error ? error.message : 'An error occurred while submitting the form';
+            setSubmitError(errorMessage);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (submitSuccess) {
+        return (
+            <div className="rounded-2xl border border-border/80 bg-card p-8 shadow-elevated">
+                <div className="flex flex-col items-center text-center">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
+                        <CheckCircle2 className="h-6 w-6" />
+                    </div>
+                    <h2 className="mt-4 text-xl font-semibold tracking-tight">You&apos;re in!</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Registration successful. We&apos;ll review your information and get back to you shortly.
+                    </p>
+                </div>
+            </div>
+        );
     }
-  };
 
-  return (
-    <Card className="w-full max-w-md mx-auto">
-      <CardHeader>
-        <CardTitle className="text-2xl">Register Your Organization</CardTitle>
-        <CardDescription>
-          Fill out this form to register your organization with us.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {submitSuccess ? (
-          <Alert className="bg-green-50 border-green-500 text-green-700">
-            <AlertDescription>
-              Registration successful! We&apos;ll review your information and get back to you soon.
-            </AlertDescription>
-          </Alert>
-        ) : (
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="organizationName">Organization Name</Label>
-              <Input
-                id="organizationName"
-                {...form.register('organizationName')}
-                placeholder="Enter your organization name"
-              />
-              {form.formState.errors.organizationName && (
-                <p className="text-sm text-red-500">{form.formState.errors.organizationName.message}</p>
-              )}
+    return (
+        <div className="rounded-2xl border border-border/80 bg-card p-8 shadow-elevated">
+            <div className="flex items-center justify-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent text-primary">
+                    <Building2 className="h-6 w-6" />
+                </div>
             </div>
+            <h1 className="mt-5 text-center text-2xl font-semibold tracking-tight">
+                Register your organization
+            </h1>
+            <p className="mt-2 text-center text-sm text-muted-foreground">
+                Set things up in under a minute.
+            </p>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                {...form.register('email')}
-                placeholder="Enter your email"
-              />
-              {form.formState.errors.email && (
-                <p className="text-sm text-red-500">{form.formState.errors.email.message}</p>
-              )}
-            </div>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="mt-6 space-y-4">
+                <div className="space-y-1.5">
+                    <Label htmlFor="organizationName">Organization name</Label>
+                    <Input
+                        id="organizationName"
+                        {...form.register('organizationName')}
+                        placeholder="e.g. TAMID at UW"
+                    />
+                    {form.formState.errors.organizationName && (
+                        <p className="text-xs text-destructive">
+                            {form.formState.errors.organizationName.message}
+                        </p>
+                    )}
+                </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="phoneNumber">Phone Number</Label>
-              <Input
-                id="phoneNumber"
-                {...form.register('phoneNumber')}
-                placeholder="Enter your phone number"
-              />
-              {form.formState.errors.phoneNumber && (
-                <p className="text-sm text-red-500">{form.formState.errors.phoneNumber.message}</p>
-              )}
-            </div>
+                <div className="space-y-1.5">
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                        id="email"
+                        type="email"
+                        {...form.register('email')}
+                        placeholder="you@org.com"
+                    />
+                    {form.formState.errors.email && (
+                        <p className="text-xs text-destructive">{form.formState.errors.email.message}</p>
+                    )}
+                </div>
 
-            {submitError && (
-              <Alert className="bg-red-50 border-red-500 text-red-700">
-                <AlertDescription>{submitError}</AlertDescription>
-              </Alert>
-            )}
-          </form>
-        )}
-      </CardContent>
-      {!submitSuccess && (
-        <CardFooter>
-          <Button 
-            className="w-full" 
-            onClick={form.handleSubmit(onSubmit)}
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? 'Submitting...' : 'Register Organization'}
-          </Button>
-        </CardFooter>
-      )}
-    </Card>
-  );
-} 
+                <div className="space-y-1.5">
+                    <Label htmlFor="phoneNumber">Phone number</Label>
+                    <Input
+                        id="phoneNumber"
+                        {...form.register('phoneNumber')}
+                        placeholder="+1 555 555 5555"
+                    />
+                    {form.formState.errors.phoneNumber && (
+                        <p className="text-xs text-destructive">
+                            {form.formState.errors.phoneNumber.message}
+                        </p>
+                    )}
+                </div>
+
+                {submitError && (
+                    <Alert variant="destructive">
+                        <AlertDescription>{submitError}</AlertDescription>
+                    </Alert>
+                )}
+
+                <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>
+                    {isSubmitting ? (
+                        <>
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Submitting...
+                        </>
+                    ) : (
+                        'Register organization'
+                    )}
+                </Button>
+            </form>
+        </div>
+    );
+}

--- a/src/components/ui/OrgQrCode.tsx
+++ b/src/components/ui/OrgQrCode.tsx
@@ -3,38 +3,47 @@ import { useRef } from 'react';
 import { QRCode } from 'react-qrcode-logo';
 import jsPDF from 'jspdf';
 import { Button } from './button';
+import { Download, QrCode } from 'lucide-react';
 
 interface OrgQrCodeProps {
-  orgName: string;
-  joinUrl: string;
+    orgName: string;
+    joinUrl: string;
 }
 
 export default function OrgQrCode({ orgName, joinUrl }: OrgQrCodeProps) {
-  const qrRef = useRef<HTMLDivElement>(null);
+    const qrRef = useRef<HTMLDivElement>(null);
 
-  const handleDownloadPdf = () => {
-    const canvas = qrRef.current?.querySelector('canvas');
-    if (!canvas) return;
-    const imgData = canvas.toDataURL('image/png');
-    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
-    pdf.setFontSize(20);
-    pdf.text(`Join ${orgName}`, 40, 60);
-    pdf.addImage(imgData, 'PNG', 40, 80, 250, 250);
-    pdf.setFontSize(12);
-    pdf.text(joinUrl, 40, 350);
-    pdf.save(`${orgName.replace(/\s+/g, '_')}_QR.pdf`);
-  };
+    const handleDownloadPdf = () => {
+        const canvas = qrRef.current?.querySelector('canvas');
+        if (!canvas) return;
+        const imgData = canvas.toDataURL('image/png');
+        const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
+        pdf.setFontSize(20);
+        pdf.text(`Join ${orgName}`, 40, 60);
+        pdf.addImage(imgData, 'PNG', 40, 80, 250, 250);
+        pdf.setFontSize(12);
+        pdf.text(joinUrl, 40, 350);
+        pdf.save(`${orgName.replace(/\s+/g, '_')}_QR.pdf`);
+    };
 
-  return (
-    <div className="flex flex-col items-center gap-4 p-4 bg-white rounded shadow-md">
-      <div ref={qrRef} className="bg-white p-4 rounded">
-        <QRCode value={joinUrl} size={220} quietZone={8} ecLevel="H" />
-      </div>
-      <div className="text-center">
-        <div className="font-semibold text-lg mb-1">Scan to Join {orgName}</div>
-        <div className="text-xs text-gray-500 break-all mb-2">{joinUrl}</div>
-        <Button onClick={handleDownloadPdf} className="mt-2">Download as PDF</Button>
-      </div>
-    </div>
-  );
-} 
+    return (
+        <div className="flex flex-col items-center">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                <QrCode className="h-3.5 w-3.5" /> Join QR Code
+            </div>
+            <div
+                ref={qrRef}
+                className="mt-3 rounded-2xl border border-border/80 bg-white p-5 shadow-soft"
+            >
+                <QRCode value={joinUrl} size={220} quietZone={8} ecLevel="H" />
+            </div>
+            <h3 className="mt-4 text-lg font-semibold tracking-tight">Join {orgName}</h3>
+            <code className="mt-2 max-w-full break-all rounded-md bg-muted px-2 py-1 text-[11px] font-mono text-muted-foreground">
+                {joinUrl}
+            </code>
+            <Button onClick={handleDownloadPdf} className="mt-4 w-full" variant="outline">
+                <Download className="h-4 w-4" /> Download as PDF
+            </Button>
+        </div>
+    );
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,13 +4,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  "relative w-full rounded-lg border px-4 py-3.5 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
   {
     variants: {
       variant: {
-        default: "bg-card text-card-foreground",
+        default: "bg-card text-card-foreground border-border/80",
         destructive:
-          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+          "text-destructive bg-destructive/5 border-destructive/30 [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+        success:
+          "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-300 dark:bg-emerald-950/40 dark:border-emerald-900/60 [&>svg]:text-current",
+        warning:
+          "text-amber-800 bg-amber-50 border-amber-200 dark:text-amber-300 dark:bg-amber-950/40 dark:border-amber-900/60 [&>svg]:text-current",
+        info:
+          "text-primary bg-accent border-primary/20 [&>svg]:text-current",
       },
     },
     defaultVariants: {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,17 +4,23 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/90",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+          "border-transparent bg-destructive text-white hover:bg-destructive/90",
+        outline: "text-foreground border-border",
+        success:
+          "border-transparent bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+        warning:
+          "border-transparent bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+        soft:
+          "border-transparent bg-accent text-accent-foreground",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,27 +5,31 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer active:scale-[0.98]",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white shadow-sm hover:bg-destructive/90 focus-visible:ring-destructive/30",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-border bg-surface text-foreground shadow-xs hover:bg-accent hover:border-border/80 dark:bg-surface dark:hover:bg-accent",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/70",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline px-0",
+        gradient:
+          "bg-gradient-to-br from-[oklch(0.32_0.15_275)] via-[oklch(0.4_0.2_290)] to-[oklch(0.28_0.16_260)] text-white shadow-md hover:shadow-lg hover:brightness-110",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-10 px-4 py-2 has-[>svg]:px-3.5",
+        sm: "h-8 rounded-md gap-1.5 px-3 text-xs has-[>svg]:px-2.5",
+        lg: "h-11 rounded-lg px-6 text-[15px] has-[>svg]:px-5",
+        xl: "h-12 rounded-xl px-7 text-base font-semibold has-[>svg]:px-6",
+        icon: "size-10",
+        "icon-sm": "size-8",
       },
     },
     defaultVariants: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-border/80 py-6 shadow-soft transition-shadow",
         className
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-tight font-semibold tracking-tight", className)}
       {...props}
     />
   )
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-sm leading-relaxed", className)}
       {...props}
     />
   )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-foreground/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border/80 bg-card text-card-foreground rounded-2xl p-6 shadow-elevated duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1.5 opacity-60 ring-offset-background transition-all hover:opacity-100 hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
@@ -73,7 +73,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:space-x-2",
       className
     )}
     {...props}
@@ -88,7 +88,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-lg font-semibold leading-tight tracking-tight",
       className
     )}
     {...props}
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-muted-foreground leading-relaxed", className)}
     {...props}
   />
 ))
@@ -119,4 +119,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-} 
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,9 +8,10 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground/70 selection:bg-primary/20 selection:text-foreground border-input flex h-10 w-full min-w-0 rounded-lg border bg-surface px-3.5 py-2 text-sm shadow-xs transition-all duration-200 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:border-ring focus-visible:ring-ring/30 focus-visible:ring-[3px] hover:border-input/80",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "dark:bg-surface",
         className
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-11 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground gap-1",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm hover:text-foreground/90",
       className
     )}
     {...props}
@@ -50,4 +50,4 @@ const TabsContent = React.forwardRef<
 ))
 TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export { Tabs, TabsList, TabsTrigger, TabsContent } 
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-20 w-full rounded-lg border bg-surface px-3.5 py-2.5 text-sm shadow-xs transition-all duration-200 outline-none focus-visible:ring-[3px] hover:border-input/80 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-surface leading-relaxed",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Redesigns the UI across landing, auth, events, mass-text, sent-messages, and core shadcn-style components (button/card/dialog/input/etc.)
- Migrates all AI-powered API routes (`ai-assist`, `email-beautify`, `email-conversation`, `document-parser`) from OpenAI (`gpt-4o-mini`) to Gemini (`gemini-2.0-flash`) via `@google/generative-ai`, switching the runtime key from `OPENAI_API_KEY` to `GEMINI_API_KEY`

## Why the Gemini migration
The OpenAI account tied to the previous key was hitting `429 insufficient_quota`, breaking email beautification and AI assistance. Gemini is already wired into the project's deps and env, so flipping the providers restores functionality without billing changes on the OpenAI side.

## Test plan
- [ ] `npm run dev` and confirm the redesigned landing/auth/events/mass-text pages render correctly on desktop and mobile
- [ ] Use the AI assist actions (improve / rephrase / shorten / etc.) in mass-text and verify responses
- [ ] Beautify an email and confirm the HTML preview renders with the expected structure
- [ ] Send a follow-up message in the email conversation panel and verify the HTML updates
- [ ] Upload a CSV/XLSX in the contacts importer and verify contacts parse correctly
- [ ] Confirm `GEMINI_API_KEY` is set in Vercel/production env before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)