### PR TITLE
Switch Gemini model from 2.0-flash to 2.5-flash

### DIFF
--- a/src/app/api/ai-assist/route.ts
+++ b/src/app/api/ai-assist/route.ts
@@ -104,7 +104,7 @@ Only include updatedHtml and updatedEnhancements if you actually made changes. I
     }
     
     const model = genAI.getGenerativeModel({
-      model: "gemini-2.0-flash",
+      model: "gemini-2.5-flash",
       systemInstruction: systemMessage,
       generationConfig: {
         temperature: 0.7,

--- a/src/app/api/document-parser/route.ts
+++ b/src/app/api/document-parser/route.ts
@@ -213,7 +213,7 @@ export async function POST(request: NextRequest) {
 
     const genAI = new GoogleGenerativeAI(process.env['GEMINI_API_KEY'] || '')
     const model = genAI.getGenerativeModel({
-      model: "gemini-2.0-flash",
+      model: "gemini-2.5-flash",
       systemInstruction: SYSTEM_PROMPT,
       generationConfig: {
         responseMimeType: "application/json",

--- a/src/app/api/email-beautify/route.ts
+++ b/src/app/api/email-beautify/route.ts
@@ -409,7 +409,7 @@ RESPOND WITH ONLY THIS JSON FORMAT (no other text):
 }`;
 
     const model = genAI.getGenerativeModel({
-      model: "gemini-2.0-flash",
+      model: "gemini-2.5-flash",
       systemInstruction: "You are an expert email designer and copywriter. You help create beautiful, professional HTML email layouts. IMPORTANT: Always respond with ONLY valid JSON in the exact format specified. Do not include any explanations, markdown formatting, or additional text outside the JSON object.",
       generationConfig: {
         temperature: 0.7,

--- a/src/app/api/email-conversation/route.ts
+++ b/src/app/api/email-conversation/route.ts
@@ -95,7 +95,7 @@ ${message}
 `;
 
         const model = genAI.getGenerativeModel({
-            model: "gemini-2.0-flash",
+            model: "gemini-2.5-flash",
             systemInstruction: SYSTEM_INSTRUCTION,
             generationConfig: {
                 temperature: 0.7,


### PR DESCRIPTION
## Summary
- AI routes were failing with `429 RESOURCE_EXHAUSTED` from the Gemini API. Direct testing of the API key confirmed that `gemini-2.0-flash` is over quota while `gemini-2.5-flash` works on the same key.
- Updates the model string in all four Gemini-powered API routes from `gemini-2.0-flash` to `gemini-2.5-flash` (the current Flash model).

Files changed:
- `src/app/api/ai-assist/route.ts`
- `src/app/api/email-beautify/route.ts`
- `src/app/api/email-conversation/route.ts`
- `src/app/api/document-parser/route.ts`

## Test plan
- [ ] Trigger an AI assist request (`/api/ai-assist`) and confirm a 200 response instead of 429
- [ ] Run an email beautify request and confirm the JSON output renders correctly
- [ ] Send a message through the email conversation endpoint and confirm the chat history is honored
- [ ] Upload a document to the document parser and confirm parsed JSON is returned
- [ ] Check server logs for any new model-compatibility warnings

## Notes
- This is a minimal fix to unblock production. Follow-up work on this branch can add retry/backoff and graceful 429 handling so future quota issues degrade gracefully instead of throwing to users.

https://claude.ai/code/session_01NFCXy9d1jwKwf8jXZdJzHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFCXy9d1jwKwf8jXZdJzHu)_